### PR TITLE
Hardcode the frontend pagination to 10 listings.

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -65,7 +65,9 @@ export async function getStaticProps() {
   let closedListings = []
 
   try {
-    const response = await axios.get(process.env.listingServiceUrl)
+    const response = await axios.get(process.env.listingServiceUrl, {
+      params: { page: "1", limit: "10" },
+    })
     const nowTime = moment()
     openListings = response.data.items.filter((listing: Listing) => {
       return (

--- a/sites/public/pages/listings/page/[page].tsx
+++ b/sites/public/pages/listings/page/[page].tsx
@@ -1,0 +1,71 @@
+import Head from "next/head"
+import axios from "axios"
+import { ListingsList, PageHeader, t } from "@bloom-housing/ui-components"
+import { Listing, PaginatedListings } from "@bloom-housing/backend-core/types"
+import Layout from "../../../layouts/application"
+import { MetaTags } from "../../../src/MetaTags"
+
+export interface ListingsProps {
+  listings: Listing[]
+}
+
+const openListings = (listings) => {
+  return listings.length > 0 ? (
+    <ListingsList listings={listings} />
+  ) : (
+    <div className="notice-block">
+      <h3 className="m-auto text-gray-800">{t("listings.noOpenListings")}</h3>
+    </div>
+  )
+}
+
+export default function ListingsPage(props: ListingsProps) {
+  const pageTitle = `${t("pageTitle.rent")} - ${t("nav.siteTitle")}`
+  const metaDescription = t("pageDescription.welcome", { regionName: t("region.name") })
+  const metaImage = "" // TODO: replace with hero image
+
+  return (
+    <Layout>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+      <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
+      <PageHeader title={t("pageTitle.rent")} />
+      <div>{openListings(props.listings)}</div>
+    </Layout>
+  )
+}
+
+export async function getStaticPaths(context: { locales: Array<string> }) {
+  try {
+    const response: PaginatedListings = await axios.get(process.env.listingServiceUrl, {
+      params: { page: "1", limit: "10" },
+    })
+
+    return {
+      paths: context.locales.flatMap((locale: string) => ({
+        params: { page: response.meta.totalPages },
+        locale: locale,
+      })),
+      fallback: "blocking",
+    }
+  } catch (e) {
+    return {
+      paths: [],
+      fallback: "blocking",
+    }
+  }
+}
+
+export async function getStaticProps(context: { params: Record<string, string> }) {
+  try {
+    const response = await axios.get(process.env.listingServiceUrl, {
+      params: { page: context.params.page, limit: "10" },
+    })
+    return { props: { listings: response.data.items }, revalidate: 120 }
+  } catch (error) {
+    console.error(error)
+  }
+
+  return { props: { listings: [] }, revalidate: 120 }
+}

--- a/sites/public/pages/listings/page/[page].tsx
+++ b/sites/public/pages/listings/page/[page].tsx
@@ -47,12 +47,12 @@ export async function getStaticPaths(context: { locales: Array<string> }) {
         params: { page: response.meta.totalPages },
         locale: locale,
       })),
-      fallback: "blocking",
+      fallback: false,
     }
   } catch (e) {
     return {
       paths: [],
-      fallback: "blocking",
+      fallback: false,
     }
   }
 }


### PR DESCRIPTION
## Issue

Addresses #54 
- [x] This change addresses only certain aspects of the issue

## Description

This will allow us to add the Detroit test data to the demo site without
overwhelming the /listings page. Later we can redirect /listings to
/listings/page/1 and add buttons for next and previous pages.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

If you have > 10 listings, you can see that the /listings page is limited to 10 and go to `/listings/page/2`, `/listings/page/3`, etc. for more pages.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
