### PR TITLE
Fix listing pagination off-by-one bug (and add tests to confirm)

### DIFF
--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -57,7 +57,7 @@ export class ListingsService {
 
       // Issue a separate "COUNT(*) from listings;" query to get the total listings count.
       totalItemsCount = await this.repository.count()
-      totalPages = Math.floor(totalItemsCount / itemsPerPage)
+      totalPages = Math.ceil(totalItemsCount / itemsPerPage)
     } else {
       // If currentPage or itemsPerPage aren't specified (or are invalid), issue the SQL query to
       // get all listings (no pagination).

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -34,24 +34,38 @@ describe("Listings", () => {
     // Make the limit 1 less than the full number of listings, so that the first page contains all
     // but the last listing.
     const page = "1"
-    const limit = (allSeeds.length - 1).toString()
-    const params = "/?page=" + page + "&limit=" + limit
+    const limit = allSeeds.length - 1
+    const params = "/?page=" + page + "&limit=" + limit.toString()
     const res = await supertest(app.getHttpServer())
       .get("/listings" + params)
       .expect(200)
     expect(res.body.items.length).toEqual(allSeeds.length - 1)
+    expect(res.body.meta).toEqual({
+      currentPage: 1,
+      itemCount: limit,
+      itemsPerPage: limit,
+      totalItems: allSeeds.length,
+      totalPages: 2,
+    })
   })
 
   it("should return the last page of paginated listings", async () => {
     // Make the limit 1 less than the full number of listings, so that the second page contains
     // only one listing.
     const page = "2"
-    const limit = (allSeeds.length - 1).toString()
-    const params = "/?page=" + page + "&limit=" + limit
+    const limit = allSeeds.length - 1
+    const params = "/?page=" + page + "&limit=" + limit.toString()
     const res = await supertest(app.getHttpServer())
       .get("/listings" + params)
       .expect(200)
     expect(res.body.items.length).toEqual(1)
+    expect(res.body.meta).toEqual({
+      currentPage: 2,
+      itemCount: 1,
+      itemsPerPage: limit,
+      totalItems: allSeeds.length,
+      totalPages: 2,
+    })
   })
 
   // TODO: replace jsonpath with SQL-level filtering


### PR DESCRIPTION
Addresses #56 and #141 
- [X] This change addresses the issue in full

## Description

This change corrects the off-by-one error in `totalPages` in the pagination metadata, and adds tests that confirm that the fix gives the intended result.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Can This Be Tested/Reviewed?

```
$ cd backend/core
$ yarn test:e2e:local
```
