### PR TITLE
Show all listings (remove a notion of hiding "closed" listings)

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -1,42 +1,21 @@
 import Head from "next/head"
 import axios from "axios"
-import moment from "moment"
-import {
-  ListingsGroup,
-  ListingsList,
-  PageHeader,
-  openDateState,
-  t,
-} from "@bloom-housing/ui-components"
+import { ListingsList, PageHeader, t } from "@bloom-housing/ui-components"
 import { Listing } from "@bloom-housing/backend-core/types"
 import Layout from "../layouts/application"
 import { MetaTags } from "../src/MetaTags"
 
 export interface ListingsProps {
-  openListings: Listing[]
-  closedListings: Listing[]
+  listings: Listing[]
 }
 
-const openListings = (listings) => {
+const listings = (listings: Listing[]) => {
   return listings.length > 0 ? (
     <ListingsList listings={listings} />
   ) : (
     <div className="notice-block">
       <h3 className="m-auto text-gray-800">{t("listings.noOpenListings")}</h3>
     </div>
-  )
-}
-
-const closedListings = (listings) => {
-  return (
-    listings.length > 0 && (
-      <ListingsGroup
-        listings={listings}
-        header={t("listings.closedListings")}
-        hideButtonText={t("listings.hideClosedListings")}
-        showButtonText={t("listings.showClosedListings")}
-      />
-    )
   )
 }
 
@@ -52,36 +31,22 @@ export default function ListingsPage(props: ListingsProps) {
       </Head>
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
       <PageHeader title={t("pageTitle.rent")} />
-      <div>
-        {openListings(props.openListings)}
-        {closedListings(props.closedListings)}
-      </div>
+      <div>{listings(props.listings)}</div>
     </Layout>
   )
 }
 
 export async function getStaticProps() {
-  let openListings = []
-  let closedListings = []
+  let listings = []
 
   try {
     const response = await axios.get(process.env.listingServiceUrl, {
       params: { page: "1", limit: "10" },
     })
-    const nowTime = moment()
-    openListings = response.data.items.filter((listing: Listing) => {
-      return (
-        openDateState(listing) ||
-        nowTime <= moment(listing.applicationDueDate) ||
-        listing.applicationDueDate == null
-      )
-    })
-    closedListings = response.data.items.filter((listing: Listing) => {
-      return nowTime > moment(listing.applicationDueDate)
-    })
+    listings = response.data.items
   } catch (error) {
     console.error(error)
   }
 
-  return { props: { openListings, closedListings } }
+  return { props: { listings } }
 }


### PR DESCRIPTION
Addresses #153 
- [X] This change addresses the issue in full

## Description

Prior to this change, if a listing had an `applicationDueDate` in the past, there would be a button at the bottom of the all-listings page that said "show closed listings" (and those closed listings would only show up if the user clicked that button). This change removes that whole "show closed listings" section and makes it so that all listings show up in the all-listings view. Example:

![image](https://user-images.githubusercontent.com/8754454/124984059-c38aa100-e006-11eb-9a24-f94b31713e91.png)

Note: the work to get rid of the red "application period closed" banner is tracked in a separate issue #157
