### PR TITLE
Pin pagination component to bottom of view

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -55,7 +55,7 @@ const ListingsPage = () => {
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
       <PageHeader title={t("pageTitle.rent")} />
       {!listingsLoading && (
-        <div className="flex-wrapper">
+        <div>
           <ListingsList listings={listingsData?.items} />
           <AgPagination
             totalItems={listingsData?.meta.totalItems}

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -55,13 +55,14 @@ const ListingsPage = () => {
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
       <PageHeader title={t("pageTitle.rent")} />
       {!listingsLoading && (
-        <div>
+        <div className="flex-wrapper">
           <ListingsList listings={listingsData?.items} />
           <AgPagination
             totalItems={listingsData?.meta.totalItems}
             totalPages={listingsData?.meta.totalPages}
             currentPage={currentPage}
             itemsPerPage={itemsPerPage}
+            sticky={true}
             quantityLabel={t("listings.totalListings")}
             setCurrentPage={setCurrentPage}
             setItemsPerPage={setItemsPerPage}

--- a/ui-components/src/global/vendor/AgPagination.tsx
+++ b/ui-components/src/global/vendor/AgPagination.tsx
@@ -6,6 +6,7 @@ type AgPaginationProps = {
   totalPages: number
   currentPage: number
   itemsPerPage: number
+  sticky?: boolean
   quantityLabel?: string
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>
   setItemsPerPage: React.Dispatch<React.SetStateAction<number>>
@@ -20,6 +21,7 @@ const AgPagination = ({
   totalPages,
   currentPage,
   itemsPerPage,
+  sticky,
   quantityLabel,
   setCurrentPage,
   setItemsPerPage,
@@ -41,8 +43,13 @@ const AgPagination = ({
     onPerPageChange && onPerPageChange(itemsPerPage)
   }
 
+  const dataPagerClassName = ["data-pager flex flex-col md:flex-row"]
+  if (sticky) {
+    dataPagerClassName.push("sticky")
+  }
+
   return (
-    <div className="data-pager flex flex-col md:flex-row">
+    <div className={dataPagerClassName.join(" ")}>
       <div className="hidden md:block">
         <Button
           className="data-pager__previous data-pager__control"

--- a/ui-components/src/global/vendor/ag_grid.scss
+++ b/ui-components/src/global/vendor/ag_grid.scss
@@ -123,6 +123,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
+  z-index: 100;
 }
 
 .data-pager__control {

--- a/ui-components/src/global/vendor/ag_grid.scss
+++ b/ui-components/src/global/vendor/ag_grid.scss
@@ -119,6 +119,12 @@
   @apply bg-gray-200;
 }
 
+.sticky {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+}
+
 .data-pager__control {
   @apply px-4;
 


### PR DESCRIPTION
Creates an option to pin the pagination UI component to the bottom of the view, and sets this to true for the main listings page.