### PR TITLE
Remove the docker services from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,13 @@ node_js:
   # Node version
   - 12
 
-services:
-  - docker
-
 cache:
   yarn: true
-
-before_install:
-  - sudo service postgresql stop
-  - sudo service redis-server stop
-  - sleep 1
 
 before_script:
   - cp sites/public/.env.template sites/public/.env
   - cp sites/partners/.env.template sites/partners/.env
   - cp backend/core/.env.template backend/core/.env
-  - docker-compose up -d redis postgres
   - yarn install:all
 
 jobs:
@@ -30,8 +21,6 @@ jobs:
       name: "Build public site"
     - script: yarn build:app:partners
       name: "Build partners site"
-    - script: yarn test:backend:core:testdbsetup && yarn test:backend:core
-      name: "Backend unit tests"
 
 env:
   global:


### PR DESCRIPTION
There is apparently a container pull limit and we'd have to
authenticate. We should instead try to use the postgres/redis built in
to Travis linux images to avoid this. Removing the backend/core tests
since those require the database to be set up.