### PR TITLE
Remove components from pagination

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -1,11 +1,5 @@
 import Head from "next/head"
-import {
-  ListingsList,
-  PageHeader,
-  AgPagination,
-  AG_PER_PAGE_OPTIONS,
-  t,
-} from "@bloom-housing/ui-components"
+import { ListingsList, PageHeader, AgPagination, t } from "@bloom-housing/ui-components"
 import Layout from "../layouts/application"
 import { MetaTags } from "../src/MetaTags"
 import React, { useEffect, useState } from "react"
@@ -17,7 +11,7 @@ const ListingsPage = () => {
 
   /* Pagination state */
   const [currentPage, setCurrentPage] = useState<number>(1)
-  const [itemsPerPage, setItemsPerPage] = useState<number>(AG_PER_PAGE_OPTIONS[0])
+  const itemsPerPage = 10
 
   function setPage(page: number) {
     if (page != currentPage) {
@@ -28,16 +22,10 @@ const ListingsPage = () => {
         },
         undefined,
         { shallow: true }
-      ) 
-      setCurrentPage(page)  
-    } 
-  }
-
-  useEffect(() => {
-    if (currentPage != 1) {
-      setPage(1)
+      )
+      setCurrentPage(page)
     }
-  }, [itemsPerPage])
+  }
 
   // Checks if the url is updated manually.
   useEffect(() => {
@@ -70,7 +58,6 @@ const ListingsPage = () => {
             sticky={true}
             quantityLabel={t("listings.totalListings")}
             setCurrentPage={setPage}
-            setItemsPerPage={setItemsPerPage}
           />
         </div>
       )}

--- a/ui-components/src/global/vendor/AgPagination.tsx
+++ b/ui-components/src/global/vendor/AgPagination.tsx
@@ -9,7 +9,7 @@ type AgPaginationProps = {
   sticky?: boolean
   quantityLabel?: string
   setCurrentPage: React.Dispatch<React.SetStateAction<number>> | ((page: number) => void)
-  setItemsPerPage: React.Dispatch<React.SetStateAction<number>>
+  setItemsPerPage?: React.Dispatch<React.SetStateAction<number>>
   onPageChange?: (page: number) => void
   onPerPageChange?: (size: number) => void
 }
@@ -20,13 +20,10 @@ const AgPagination = ({
   totalItems,
   totalPages,
   currentPage,
-  itemsPerPage,
   sticky,
   quantityLabel,
   setCurrentPage,
-  setItemsPerPage,
   onPageChange,
-  onPerPageChange,
 }: AgPaginationProps) => {
   const onNextClick = () => {
     setCurrentPage(currentPage + 1)
@@ -36,11 +33,6 @@ const AgPagination = ({
   const onPrevClick = () => {
     setCurrentPage(currentPage - 1)
     onPageChange && onPageChange(currentPage)
-  }
-
-  const onRowLimitChange = (size: string) => {
-    setItemsPerPage(parseInt(size))
-    onPerPageChange && onPerPageChange(itemsPerPage)
   }
 
   const dataPagerClassName = ["data-pager flex flex-col md:flex-row"]
@@ -66,51 +58,6 @@ const AgPagination = ({
             {totalItems}
           </span>
           {quantityLabel && <span className="field-label">{quantityLabel}</span>}
-        </div>
-
-        <div className="flex mt-5 md:mt-0 md:items-center">
-          <div className="field data-pager__control md:mb-0">
-            <label className="field-label font-sans" htmlFor="page-size">
-              {t("t.show")}
-            </label>
-            <select
-              name="page-size"
-              id="page-size"
-              value={itemsPerPage}
-              onChange={({ target }) => onRowLimitChange(target.value)}
-            >
-              {AG_PER_PAGE_OPTIONS.map((item) => (
-                <option key={item} value={item}>
-                  {item}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="field data-pager__control">
-            <label className="field-label font-sans" htmlFor="page-jump">
-              {t("t.jumpTo")}
-            </label>
-            <select
-              name="page-jump"
-              id="page-jump"
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setCurrentPage(parseInt(e.target.value))
-              }
-              value={currentPage}
-            >
-              {Array(totalPages)
-                .fill(totalPages)
-                .map((_, i) => {
-                  const value = i + 1
-                  return (
-                    <option key={value} value={value}>
-                      {value}
-                    </option>
-                  )
-                })}
-            </select>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Removes the "Items Per Page" and "Jump to Page" components from the pagination UI components.

This makes the paginated listings view more mobile friendly.

Before the change:
![image](https://user-images.githubusercontent.com/83078310/125959094-caefad75-fb74-4ce2-8978-40f8107ea190.png)


After the change: 
![image](https://user-images.githubusercontent.com/83078310/125959059-32ffc2a6-5f50-4363-a5ce-c46f0dc32221.png)
