### PR TITLE
Fix the bug that causes the unit summaries not to show up in the /listings view

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -300,12 +300,19 @@ export class ListingDto extends OmitType(Listing, [
   yearBuilt?: number | null
 
   @Expose()
-  @ApiProperty({ type: UnitsSummarized })
-  get unitsSummarized(): UnitsSummarized | undefined {
-    if (Array.isArray(this.units) && this.units.length > 0) {
-      return transformUnits(this.units as Unit[])
-    }
-  }
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => UnitsSummarized)
+  @Transform(
+    (value, obj: Listing) => {
+      const units = obj.property.units
+      if (Array.isArray(units) && units.length > 0) {
+        return transformUnits(units)
+      }
+    },
+    { toClassOnly: true }
+  )
+  unitsSummarized: UnitsSummarized | undefined
 }
 
 export class PaginatedListingsDto extends PaginationFactory<ListingDto>(ListingDto) {}


### PR DESCRIPTION
## Issue

Addresses #183 

- [X] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

I can't fully explain what this change is doing or why it works. How I arrived at this change: by observing that the `unitsSummarized` field in `ListingDto` was the only field that appeared to be defined by a `get` method; all other derived fields were decorated with the `@Transform` decorator (which the [NestJS documentation](https://docs.nestjs.com/techniques/serialization#transform) is unfortunately quite light on.)

I dug into code that's involved in the serialization and recorded thoughts in https://github.com/CityOfDetroit/bloom/issues/183#issuecomment-885894007. That led to an observation of something being different between our code and Exygy's, but that difference didn't point towards an obvious solution. At that point, I stopped trying to understand the problem and switched to just trying reasonable things to fix the problem. And that's how I arrived at using the `@Transform` decorator to derive the `unitsSummarized` field.

The result: we got our unit summary table in the listing view back.

![image](https://user-images.githubusercontent.com/8754454/126839182-fca283b0-5e42-4d57-a17f-e4d77f5439c4.png)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Viewed the fix in 
- [X] Desktop View
- [X] Mobile View

Also confirmed that there were no new failing tests in `backend/core`.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
