### PR TITLE
Add cast from enum to string before lowercasing in filtered query

### DIFF
--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -57,7 +57,7 @@ export function addFilters<FilterParams, FilterFieldMap>(
           // Each WHERE param must be unique across the entire QueryBuilder
           const whereParameterName = `${filterType}_${i}`
           qb.andWhere(
-            `LOWER(${filterTypeToFieldMap[filterType.toLowerCase()]}) ${
+            `LOWER(CAST(${filterTypeToFieldMap[filterType.toLowerCase()]} as text)) ${
               comparisonsForCurrentFilter[i]
             } LOWER(:${whereParameterName})`,
             {


### PR DESCRIPTION
## Issue #202 

Addresses #202

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
In #257 we added lowercased the comparison in `addFilters()` so that it would be case-insensitive, but that broke comparisons with enum types.
To fix this, we cast all types to strings in the query

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [ ] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
