### PR TITLE
Move where clauses and pagination to subquery, so filtered results return all listing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Added:
   - Made `addFilters()` more generic ([#257](https://github.com/CityOfDetroit/bloom/pull/257))
   - Fixed lowercaseing issue in query built by `addFilters()` ([#264](https://github.com/CityOfDetroit/bloom/pull/264))
+  - Move where clauses and pagination to subquery, so filtered results return all listing data ([#271](https://github.com/CityOfDetroit/bloom/pull/271))
 
 ## Detroit Team M7
 - Added:

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -37,6 +37,7 @@ const mockInnerQueryBuilder = {
   andWhere: jest.fn().mockReturnThis(),
   offset: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
+  getParameters: jest.fn().mockReturnValue({ param1: "param1value" }),
   getQuery: jest.fn().mockReturnValue("innerQuery"),
   getCount: jest.fn().mockReturnValue(7),
 }
@@ -114,9 +115,7 @@ describe("ListingsService", () => {
     })
 
     it("should throw an exception if an unsupported filter is used", async () => {
-      mockListingsRepo.createQueryBuilder
-        .mockReturnValueOnce(mockInnerQueryBuilder)
-        .mockReturnValueOnce(mockQueryBuilder)
+      mockListingsRepo.createQueryBuilder.mockReturnValueOnce(mockInnerQueryBuilder)
 
       const queryParams: ListingsQueryParams = {
         filter: {

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -17,14 +17,34 @@ const origin = "localhost"
 const mockListings = [
   { id: "asdf1", property: { id: "test-property1", units: [] }, preferences: [], status: "closed" },
   { id: "asdf2", property: { id: "test-property2", units: [] }, preferences: [], status: "closed" },
+  { id: "asdf3", property: { id: "test-property3", units: [] }, preferences: [], status: "closed" },
+  { id: "asdf4", property: { id: "test-property4", units: [] }, preferences: [], status: "closed" },
+  { id: "asdf5", property: { id: "test-property5", units: [] }, preferences: [], status: "closed" },
+  { id: "asdf6", property: { id: "test-property6", units: [] }, preferences: [], status: "closed" },
+  { id: "asdf7", property: { id: "test-property7", units: [] }, preferences: [], status: "closed" },
 ]
+const mockFilteredListings = mockListings.slice(0, 2)
 const mockListingsDto = mapTo<ListingDto, Listing>(ListingDto, mockListings as Listing[])
+const mockFilteredListingsDto = mapTo<ListingDto, Listing>(
+  ListingDto,
+  mockFilteredListings as Listing[]
+)
+const mockInnerQueryBuilder = {
+  select: jest.fn().mockReturnThis(),
+  leftJoin: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  offset: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  getQuery: jest.fn().mockReturnValue("innerQuery"),
+  getCount: jest.fn().mockReturnValue(7),
+}
 const mockQueryBuilder = {
   leftJoinAndSelect: jest.fn().mockReturnThis(),
-  orderBy: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
-  take: jest.fn().mockReturnThis(),
-  skip: jest.fn().mockReturnThis(),
+  setParameters: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
   getMany: jest.fn().mockReturnValue(mockListings),
 }
 const mockListingsRepo = {
@@ -59,13 +79,20 @@ describe("ListingsService", () => {
 
   describe("getListingsList", () => {
     it("should not add a WHERE clause if no filters are applied", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
+
       const listings = await service.list(origin, {})
 
       expect(listings.items).toEqual(mockListingsDto)
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledTimes(0)
+      expect(mockInnerQueryBuilder.andWhere).toHaveBeenCalledTimes(0)
     })
 
     it("should add a WHERE clause if the neighborhood filter is applied", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
       const expectedNeighborhood = "Fox Creek"
 
       const queryParams: ListingsQueryParams = {
@@ -78,7 +105,7 @@ describe("ListingsService", () => {
       const listings = await service.list(origin, queryParams)
 
       expect(listings.items).toEqual(mockListingsDto)
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      expect(mockInnerQueryBuilder.andWhere).toHaveBeenCalledWith(
         "LOWER(CAST(property.neighborhood as text)) = LOWER(:neighborhood_0)",
         {
           neighborhood_0: expectedNeighborhood,
@@ -87,6 +114,10 @@ describe("ListingsService", () => {
     })
 
     it("should throw an exception if an unsupported filter is used", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
+
       const queryParams: ListingsQueryParams = {
         filter: {
           $comparison: Compare["="],
@@ -100,28 +131,84 @@ describe("ListingsService", () => {
         new HttpException("Filter Not Implemented", HttpStatus.NOT_IMPLEMENTED)
       )
     })
-  })
 
-  it("should call take() and skip() if pagination params are specified", async () => {
-    // Empty params (no pagination) -> no take/skip
-    let params = {}
-    let listings = await service.list(origin, params)
-    expect(listings.items).toEqual(mockListingsDto)
-    expect(mockQueryBuilder.take).toHaveBeenCalledTimes(0)
-    expect(mockQueryBuilder.skip).toHaveBeenCalledTimes(0)
+    it("should not call limit() and offset() if pagination params are not specified", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
 
-    // Invalid pagination params (page specified, but not limit) -> no take/skip
-    params = { page: 3 }
-    listings = await service.list(origin, params)
-    expect(listings.items).toEqual(mockListingsDto)
-    expect(mockQueryBuilder.take).toHaveBeenCalledTimes(0)
-    expect(mockQueryBuilder.skip).toHaveBeenCalledTimes(0)
+      // Empty params (no pagination) -> no limit/offset
+      const params = {}
+      const listings = await service.list(origin, params)
 
-    // Valid pagination params -> skip and take called appropriately
-    params = { page: 3, limit: 7 }
-    listings = await service.list(origin, params)
-    expect(listings.items).toEqual(mockListingsDto)
-    expect(mockQueryBuilder.take).toHaveBeenCalledWith(7)
-    expect(mockQueryBuilder.skip).toHaveBeenCalledWith(14)
+      expect(listings.items).toEqual(mockListingsDto)
+      expect(mockInnerQueryBuilder.limit).toHaveBeenCalledTimes(0)
+      expect(mockInnerQueryBuilder.offset).toHaveBeenCalledTimes(0)
+    })
+
+    it("should not call limit() and offset() if incomplete pagination params are specified", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
+
+      // Invalid pagination params (page specified, but not limit) -> no limit/offset
+      const params = { page: 3 }
+      const listings = await service.list(origin, params)
+
+      expect(listings.items).toEqual(mockListingsDto)
+      expect(mockInnerQueryBuilder.limit).toHaveBeenCalledTimes(0)
+      expect(mockInnerQueryBuilder.offset).toHaveBeenCalledTimes(0)
+      expect(listings.meta).toEqual({
+        currentPage: 1,
+        itemCount: mockListings.length,
+        itemsPerPage: mockListings.length,
+        totalItems: mockListings.length,
+        totalPages: 1,
+      })
+    })
+
+    it("should not call limit() and offset() if invalid pagination params are specified", async () => {
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
+
+      // Invalid pagination params (page specified, but not limit) -> no limit/offset
+      const params = { page: ("hello" as unknown) as number } // force the type for testing
+      const listings = await service.list(origin, params)
+
+      expect(listings.items).toEqual(mockListingsDto)
+      expect(mockInnerQueryBuilder.limit).toHaveBeenCalledTimes(0)
+      expect(mockInnerQueryBuilder.offset).toHaveBeenCalledTimes(0)
+      expect(listings.meta).toEqual({
+        currentPage: 1,
+        itemCount: mockListings.length,
+        itemsPerPage: mockListings.length,
+        totalItems: mockListings.length,
+        totalPages: 1,
+      })
+    })
+
+    it("should call limit() and offset() if pagination params are specified", async () => {
+      mockQueryBuilder.getMany.mockReturnValueOnce(mockFilteredListings)
+      mockListingsRepo.createQueryBuilder
+        .mockReturnValueOnce(mockInnerQueryBuilder)
+        .mockReturnValueOnce(mockQueryBuilder)
+
+      // Valid pagination params -> offset and limit called appropriately
+      const params = { page: 3, limit: 2 }
+      const listings = await service.list(origin, params)
+
+      expect(listings.items).toEqual(mockFilteredListingsDto)
+      expect(mockInnerQueryBuilder.limit).toHaveBeenCalledWith(2)
+      expect(mockInnerQueryBuilder.offset).toHaveBeenCalledWith(4)
+      expect(mockInnerQueryBuilder.getCount).toHaveBeenCalledTimes(1)
+      expect(listings.meta).toEqual({
+        currentPage: 3,
+        itemCount: 2,
+        itemsPerPage: 2,
+        totalItems: mockListings.length,
+        totalPages: 4,
+      })
+    })
   })
 })

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -46,6 +46,8 @@ export class ListingsService {
       .leftJoinAndSelect("units.amiChart", "amiChart")
       .leftJoinAndSelect("listings.jurisdiction", "jurisdiction")
       .leftJoinAndSelect("listings.reservedCommunityType", "reservedCommunityType")
+      // add the inner query parameters to the outer query cause there's a bug
+      .setParameter("maxOccupancy", 3)
 
     if (!innerFilteredQuery) {
       return qb
@@ -62,6 +64,7 @@ export class ListingsService {
       .leftJoin("listings.property", "property")
       .leftJoin("property.units", "units")
       .andWhere("units.maxOccupancy = :maxOccupancy", { maxOccupancy: 3 })
+      // .andWhere("units.maxOccupancy = 3")
       .groupBy("listings.id")
       .orderBy({ "listings.id": "DESC" })
     const innerCount = await innerQuery.getCount()

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -86,8 +86,8 @@ export class ListingsService {
     let listings: Listing[]
 
     const paginate =
-    // currentPage and itemsPerPage are read in from the querystring, so we
-    // we confirm the type before proceeding
+      // currentPage and itemsPerPage are read in from the querystring, so we
+      // we confirm the type before proceeding
       typeof paginationInfo.currentPage === "number" &&
       paginationInfo.currentPage > 0 &&
       typeof paginationInfo.itemsPerPage === "number" &&

--- a/backend/core/src/shared/dto/filter.dto.ts
+++ b/backend/core/src/shared/dto/filter.dto.ts
@@ -13,5 +13,5 @@ export class BaseFilter {
     example: "=",
     default: Compare["="],
   })
-  $comparison: Compare
+  $comparison: Compare | Compare[]
 }

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -6,16 +6,16 @@ import { WhereExpression } from "typeorm"
  * @param filterParams
  * @param filterTypeToFieldMap
  * @param innerQb The inner query on which filters are applied.
- * @param whereParameters The whereParamters used for the inner query
+ * @param whereParameters Passes out the whereParamters used for the inner query.
  */
 /**
  * Add filters to provided QueryBuilder, using the provided map to find the field name.
  * The order of the params matters:
  * - A $comparison must be first.
  * - Comparisons in $comparison will be applied to each filter in order.
- * Passing in the outer query is necessary due to a bug in TypeORM: The WHERE
- * params are dropped from the inner query, so they must be added to the outer
- * query.
+ * Passing out the WHERE parameters is necessary due to a bug in TypeORM: The
+ * WHERE params are dropped from the inner query, so they must be added to the
+ * outer query manually.
  */
 export function addFilters<FilterParams, FilterFieldMap>(
   filterParams: FilterParams,
@@ -64,7 +64,10 @@ export function addFilters<FilterParams, FilterFieldMap>(
           innerQb.andWhere(
             `LOWER(${filterTypeToFieldMap[filterType.toLowerCase()]}) ${
               comparisonsForCurrentFilter[i]
-            } LOWER(:${whereParameterName})`
+            } LOWER(:${whereParameterName})`,
+            {
+              [whereParameterName]: val,
+            }
           )
           whereParameters[whereParameterName] = val
         })

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -34,7 +34,7 @@ export function addFilters<FilterParams, FilterFieldMap>(
     if (filterType === "$comparison") {
       if (Array.isArray(value)) {
         comparisons = value
-      } else if (typeof value == "string") {
+      } else if (typeof value === "string") {
         comparisons = [value]
       }
     } else {
@@ -43,7 +43,7 @@ export function addFilters<FilterParams, FilterFieldMap>(
         // handle multiple values for the same key
         if (Array.isArray(value)) {
           values = value
-        } else if (typeof value == "string") {
+        } else if (typeof value === "string") {
           values = [value]
         }
 

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -6,22 +6,17 @@ import { WhereExpression } from "typeorm"
  * @param filterParams
  * @param filterTypeToFieldMap
  * @param innerQb The inner query on which filters are applied.
- * @param whereParameters Passes out the whereParamters used for the inner query.
  */
 /**
  * Add filters to provided QueryBuilder, using the provided map to find the field name.
  * The order of the params matters:
  * - A $comparison must be first.
  * - Comparisons in $comparison will be applied to each filter in order.
- * Passing out the WHERE parameters is necessary due to a bug in TypeORM: The
- * WHERE params are dropped from the inner query, so they must be added to the
- * outer query manually.
  */
 export function addFilters<FilterParams, FilterFieldMap>(
   filterParams: FilterParams,
   filterTypeToFieldMap: FilterFieldMap,
-  innerQb: WhereExpression,
-  whereParameters: { [key: string]: string }
+  innerQb: WhereExpression
 ): void {
   let comparisons: string[],
     comparisonCount = 0
@@ -69,7 +64,6 @@ export function addFilters<FilterParams, FilterFieldMap>(
               [whereParameterName]: val,
             }
           )
-          whereParameters[whereParameterName] = val
         })
       }
     }


### PR DESCRIPTION
# Move where clauses and pagination to subquery, so filtered results return all listing data 

## Issue #258 

Addresses #258

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
Moves `WHERE` clauses and pagination to a subquery, so filtered results return all listing data.

Previously, if we filtered on units or preferences, only the units or preferences that match the query were returned. Now, everything about a building that contains matching units is returned

Also:
- The subquery gets a list of matching ids by only joining the tables necessary for filtering, before joining everything together
- Fixes a bug where `meta.totalItems` was the total number of listings, not the total number of listings that match the filters
- Refactors pagination logic to use the same subquery as the filters
- Updates tests to match, and test `meta` details
- Moves sorting logic back into the query ([this comment](https://github.com/CityOfDetroit/affordable-housing-app/issues/88#issuecomment-865329223) no longer applies now that we're not using `take()` and `skip()`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?
Test with paths like:
- /listings?filter[$comparison]=%3C%3E&filter[neighborhood]=Foster%20City&page=1&limit=90
- /listings?filter[$comparison]=%3C%3E&filter[neighborhood]=Foster%20City&page=2&limit=2
- /listings?filter[$comparison]==&filter[neighborhood]=Foster%20City&page=1&limit=90
- /listings

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
