### PR TITLE
Update listings-importer library to match new unitType storage details

### DIFF
--- a/backend/core/scripts/listings-importer.ts
+++ b/backend/core/scripts/listings-importer.ts
@@ -57,6 +57,29 @@ async function uploadAmiCharts(units) {
   }
 }
 
+async function uploadUnitTypes(units) {
+  const unitTypesService = new client.UnitTypesService()
+  const unitTypes = await unitTypesService.list()
+
+  for (const unit of units) {
+    const unitTypeStr = unit.unitType
+    if (!unitTypeStr) {
+      console.log(unit)
+      console.log("Error: each unit must have a unitType.")
+      process.exit(1)
+    }
+
+    // Look for the unitType by name.
+    let unitType = unitTypes.filter((unitType) => unitType.name == unitTypeStr)[0]
+
+    // If it doesn't exist, create it.
+    if (!unitType) {
+      unitType = await unitTypesService.create({ body: { name: unitTypeStr } })
+    }
+    unit.unitType = unitType
+  }
+}
+
 async function uploadProperty(property) {
   try {
     const propertyService = new client.PropertiesService()
@@ -112,6 +135,7 @@ export async function importListing(apiUrl, email, password, listing) {
   delete listing.property
 
   await uploadAmiCharts(property.units)
+  await uploadUnitTypes(property.units)
 
   property.listings = [listing]
   property = await uploadProperty(property)


### PR DESCRIPTION
Just a quick fix to the `listings-importer.ts` library to account for the change from `unitType` being a string in the `units` table to `unitType` being its own separate entity (in a separate table in the DB).

Before this change: `import-listing-from-json-file.ts` with input `minimal-listing.json` failed with "unitType.nested property unitType must be either object or array".

With this change: `import-listing-from-json-file.ts` with input `minimal-listing.json` succeeds.