### PR TITLE
Override primary button hover styles

### DIFF
--- a/sites/partners/styles/overrides.scss
+++ b/sites/partners/styles/overrides.scss
@@ -25,3 +25,10 @@
   // Table row hover background color
   --ag-row-hover-color: #f2f2f2;
 }
+
+Button.button.is-primary {
+  &:hover {
+    @apply bg-primary-light;
+    @apply text-black;
+  }
+}

--- a/sites/partners/styles/overrides.scss
+++ b/sites/partners/styles/overrides.scss
@@ -26,9 +26,7 @@
   --ag-row-hover-color: #f2f2f2;
 }
 
-Button.button.is-primary {
-  &:hover {
-    @apply bg-primary-light;
-    @apply text-black;
-  }
+Button.button.is-primary:hover {
+  @apply bg-primary-light;
+  @apply text-black;
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -31,3 +31,11 @@ h5.form-card__header_title {
 .field-note {
   @apply font-normal;
 }
+
+Button.button.is-primary,
+a.button.is-primary {
+  &:hover {
+    @apply bg-primary-light;
+    @apply text-black;
+  }
+}

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -32,10 +32,8 @@ h5.form-card__header_title {
   @apply font-normal;
 }
 
-Button.button.is-primary,
-a.button.is-primary {
-  &:hover {
-    @apply bg-primary-light;
-    @apply text-black;
-  }
+Button.button.is-primary:hover,
+a.button.is-primary:hover {
+  @apply bg-primary-light;
+  @apply text-black;
 }


### PR DESCRIPTION
## Issue
#221 

Addresses # (issue)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Overrides button hover styles.

Because the Detroit color palette doesn't differentiate between "dark" and "darker" background colors, there was no noticeable difference in hover styles for primary buttons. This change overrides the hover color to be lighter, and changes the text color to black.

Examples:
![image](https://user-images.githubusercontent.com/83078310/127394352-424a36b3-d4b0-49b9-9f3a-9ff8f16bf4cd.png)
![image](https://user-images.githubusercontent.com/83078310/127394368-303b1275-50bc-4d55-bf1c-752e00a74a62.png)

![image](https://user-images.githubusercontent.com/83078310/127394399-e5e77857-90a9-45bd-bdf5-12ae86ba7dae.png)
![image](https://user-images.githubusercontent.com/83078310/127394423-3476bdfd-54d4-4400-9978-b2306863ffe4.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

There are examples of primary buttons in the public sign-in page, eligibility welcome page, and listing details page.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
