### PR TITLE
Allow non-admin to access preferences

### DIFF
--- a/backend/core/src/auth/authz_policy.csv
+++ b/backend/core/src/auth/authz_policy.csv
@@ -9,6 +9,7 @@ p, anonymous, user, true, create
 p, admin, asset, true, .*
 
 p, admin, preference, true, .*
+p, user, preference, true, .*
 
 p, admin, applicationMethod, true, .*
 

--- a/backend/core/test/authz/authz.e2e-spec.ts
+++ b/backend/core/test/authz/authz.e2e-spec.ts
@@ -13,7 +13,7 @@ jest.setTimeout(30000)
 describe("Authz", () => {
   let app: INestApplication
   let userAccessToken: string
-  const adminOnlyEndpoints = ["/preferences", "/units", "/translations"]
+  const adminOnlyEndpoints = ["/units", "/translations"]
   const applicationsEndpoint = "/applications"
   const listingsEndpoint = "/listings"
   const userEndpoint = "/user"

--- a/sites/partners/src/listings/PaperListingForm/sections/Preferences.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Preferences.tsx
@@ -87,15 +87,17 @@ const Preferences = ({ preferences, setPreferences }: PreferencesProps) => {
   }, [dragOrder])
 
   // Fetch and filter all preferences
-  const { data: preferencesData = [] } = usePreferenceList()
+  const { data: preferencesData = [], error: preferencesError } = usePreferenceList()
   useEffect(() => {
-    setUniquePreferences(
-      preferencesData.reduce(
-        (items, item) =>
-          items.find((x) => x.description === item.description) ? [...items] : [...items, item],
-        []
+    if (!preferencesError) {
+      setUniquePreferences(
+        preferencesData.reduce(
+          (items, item) =>
+            items.find((x) => x.description === item.description) ? [...items] : [...items, item],
+          []
+        )
       )
-    )
+    }
   }, [preferencesData])
 
   const formMethods = useFormContext()
@@ -111,6 +113,11 @@ const Preferences = ({ preferences, setPreferences }: PreferencesProps) => {
   const draggableTableHeaders = {
     name: "t.name",
     action: "",
+  }
+
+  // Bail early if there's an error fetching preferenes.
+  if (preferencesError) {
+    return null
   }
 
   return (

--- a/sites/partners/src/listings/PaperListingForm/sections/Preferences.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Preferences.tsx
@@ -100,6 +100,11 @@ const Preferences = ({ preferences, setPreferences }: PreferencesProps) => {
     }
   }, [preferencesData])
 
+  // Bail early if there's an error fetching preferenes.
+  if (preferencesError) {
+    return null
+  }
+
   const formMethods = useFormContext()
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, getValues } = formMethods
@@ -113,11 +118,6 @@ const Preferences = ({ preferences, setPreferences }: PreferencesProps) => {
   const draggableTableHeaders = {
     name: "t.name",
     action: "",
-  }
-
-  // Bail early if there's an error fetching preferenes.
-  if (preferencesError) {
-    return null
   }
 
   return (


### PR DESCRIPTION
## Issue
#306 

Addresses # (issue)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Allows non-admins to pull listing preference data.

Also makes the preference page more resilient to failures by avoiding an infinite rendering loop if there's an error fetching preferences, and failing to load if there's an error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Log in as a non-admin and try to edit listing preferenes. Notice how the page doesn't freeze. :)

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
