### PR TITLE
Revert pagination defaults to upstream

### DIFF
--- a/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
+++ b/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
@@ -33,10 +33,7 @@ export class ApplicationFlaggedSetsService {
   async listPaginated(queryParams: PaginatedApplicationFlaggedSetQueryParams) {
     const results = await paginate<ApplicationFlaggedSet>(
       this.afsRepository,
-      {
-        limit: queryParams.limit > 0 ? queryParams.limit : Number.MAX_SAFE_INTEGER,
-        page: queryParams.page > 0 ? queryParams.page : 1,
-      },
+      { limit: queryParams.limit, page: queryParams.page },
       {
         relations: ["listing", "applications"],
         where: {

--- a/backend/core/src/applications/applications.service.ts
+++ b/backend/core/src/applications/applications.service.ts
@@ -80,10 +80,7 @@ export class ApplicationsService {
     params: PaginatedApplicationListQueryParams
   ): Promise<Pagination<Application>> {
     const qb = this._getQb(params)
-    const result = await paginate(qb, {
-      limit: params.limit > 0 ? params.limit : 10,
-      page: params.page > 0 ? params.page : 1,
-    })
+    const result = await paginate(qb, { limit: params.limit, page: params.page })
     await Promise.all(
       result.items.map(async (application) => {
         await this.authorizeUserAction(this.req.user, application, authzActions.read)

--- a/backend/core/src/shared/dto/pagination.dto.ts
+++ b/backend/core/src/shared/dto/pagination.dto.ts
@@ -41,11 +41,11 @@ export class PaginationQueryParams {
     type: Number,
     example: 1,
     required: false,
-    default: -1,
+    default: 1,
   })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
-  @Transform((value: string | undefined) => (value ? parseInt(value) : -1), {
+  @Transform((value: string | undefined) => (value ? parseInt(value) : 1), {
     toClassOnly: true,
   })
   page?: number
@@ -55,11 +55,11 @@ export class PaginationQueryParams {
     type: Number,
     example: 10,
     required: false,
-    default: -1,
+    default: 10,
   })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
-  @Transform((value: string | undefined) => (value ? parseInt(value) : -1), {
+  @Transform((value: string | undefined) => (value ? parseInt(value) : 10), {
     toClassOnly: true,
   })
   limit?: number


### PR DESCRIPTION
# Pull Request Template

## Issue #192

Addresses #192 

- [x] This change addresses the issue in full

## Description

In https://github.com/bloom-housing/bloom/pull/1578 we added a new PaginationAllowsAllQueryParams params type for listings. Now we can revert the changes we made to the query params defaults in https://github.com/CityOfDetroit/bloom/pull/133

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
