### PR TITLE
Add support for comma-separated lists to filter and ensure comparisons are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 - Added:
   - Added fields to Listing and Property to accommodate Detroit listing data ([#311](https://github.com/CityOfDetroit/bloom/pull/311))
   - Add eligibility questionnaire validation ([#327](https://github.com/CityOfDetroit/bloom/pull/327))
+  - Add support for comma-separated lists to filters ([#356](https://github.com/CityOfDetroit/bloom/pull/356))
 
 ## Detroit Team M8
 

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -162,8 +162,6 @@ describe("ListingsService", () => {
           // so we force it to an invalid type for testing.
           $comparison: "); DROP TABLE Students;" as Compare,
           name: "test name",
-          // The querystring can contain unknown fields that aren't on the
-          // ListingFilterParams type, so we force it to the type for testing
         } as ListingFilterParams,
       }
 

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -112,7 +112,7 @@ describe("ListingsService", () => {
       mockListingsRepo.createQueryBuilder
         .mockReturnValueOnce(mockInnerQueryBuilder)
         .mockReturnValueOnce(mockQueryBuilder)
-      const expectedNeighborhoodString = "Fox Creek, , Coliseum," // intential extra and trailing commas for test
+      const expectedNeighborhoodString = "Fox Creek, , Coliseum," // intentional extra and trailing commas for test
       // lowercased, trimmed spaces, filtered empty
       const expectedNeighborhoodArray = ["fox creek", "coliseum"]
 
@@ -142,12 +142,33 @@ describe("ListingsService", () => {
           $comparison: Compare["="],
           otherField: "otherField",
           // The querystring can contain unknown fields that aren't on the
-          // ListingFilterParams type, so we force it to the type for testing
+          // ListingFilterParams type, so we force it to the type for testing.
         } as ListingFilterParams,
       }
 
       await expect(service.list(origin, queryParams)).rejects.toThrow(
         new HttpException("Filter Not Implemented", HttpStatus.NOT_IMPLEMENTED)
+      )
+    })
+
+    //TODO(avaleske): A lot of these tests should be moved to a spec file specific to the filters code.
+    it("should throw an exception if an unsupported comparison is used", async () => {
+      mockListingsRepo.createQueryBuilder.mockReturnValueOnce(mockInnerQueryBuilder)
+
+      const queryParams: ListingsQueryParams = {
+        filter: {
+          // The value of the filter[$comparison] query param is not validated,
+          // and the type system trusts that whatever is provided is correct,
+          // so we force it to an invalid type for testing.
+          $comparison: "); DROP TABLE Students;" as Compare,
+          name: "test name",
+          // The querystring can contain unknown fields that aren't on the
+          // ListingFilterParams type, so we force it to the type for testing
+        } as ListingFilterParams,
+      }
+
+      await expect(service.list(origin, queryParams)).rejects.toThrow(
+        new HttpException("Comparison Not Implemented", HttpStatus.NOT_IMPLEMENTED)
       )
     })
 

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -125,7 +125,7 @@ describe("ListingsService", () => {
 
       const listings = await service.list(origin, queryParams)
 
-      expect(listings.items).toEqual(mockListingsDto)
+      expect(listings.items).toEqual(mockListings)
       expect(mockInnerQueryBuilder.andWhere).toHaveBeenCalledWith(
         "LOWER(CAST(property.neighborhood as text)) IN (:...neighborhood_0)",
         {

--- a/backend/core/src/shared/dto/filter.dto.ts
+++ b/backend/core/src/shared/dto/filter.dto.ts
@@ -5,6 +5,7 @@ import { Expose } from "class-transformer"
 export enum Compare {
   "=" = "=",
   "<>" = "<>",
+  "IN" = "IN",
 }
 export class BaseFilter {
   @Expose()

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus } from "@nestjs/common"
 import { WhereExpression } from "typeorm"
+import { Compare } from "../dto/filter.dto"
 
 /**
  *
@@ -57,14 +58,29 @@ export function addFilters<FilterParams, FilterFieldMap>(
         values.forEach((val: string, i: number) => {
           // Each WHERE param must be unique across the entire QueryBuilder
           const whereParameterName = `${filterType}_${i}`
-          qb.andWhere(
-            `LOWER(CAST(${filterTypeToFieldMap[filterType.toLowerCase()]} as text)) ${
-              comparisonsForCurrentFilter[i]
-            } LOWER(:${whereParameterName})`,
-            {
-              [whereParameterName]: val,
-            }
-          )
+
+          if (comparisonsForCurrentFilter[i] === Compare.IN) {
+            qb.andWhere(
+              `LOWER(CAST(${filterTypeToFieldMap[filterType.toLowerCase()]} as text)) ${
+                comparisonsForCurrentFilter[i]
+              } (:...${whereParameterName})`,
+              {
+                [whereParameterName]: val
+                  .split(",")
+                  .map((s) => s.trim().toLowerCase())
+                  .filter((s) => s.length !== 0),
+              }
+            )
+          } else {
+            qb.andWhere(
+              `LOWER(CAST(${filterTypeToFieldMap[filterType.toLowerCase()]} as text)) ${
+                comparisonsForCurrentFilter[i]
+              } LOWER(:${whereParameterName})`,
+              {
+                [whereParameterName]: val,
+              }
+            )
+          }
         })
       }
     }


### PR DESCRIPTION
# Pull Request Template

## Issue
Add support for IN comparison for lists

Addresses #255 

- [x] This change addresses the issue in full

## Description
Add support for commas-separated lists to filters. Also ensures that provided comparison is valid.
- Adds an `IN` comparison type
- If the filter specifies an `IN` comparison, treat the filter value as a comma-separated list
- Handles if there are extra commas and spaces between the commas and the value
- Add tests to listings service spec. (We should also start writing tests for the addFilters code itself)
- Adds switch statement to `addFilters()` to ensure that the provided comparison is a valid one

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City,Coliseum,`
- [x] Returns 1: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City`
- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City, Coliseum,  ,`
- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster City, Coliseum. ,`
- [x] Returns a 400 error `http://localhost:3100/listings?filter[$comparison]=fake%20comparison&filter[neighborhood]=Foster%20City`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
