### PR TITLE
Run the longer tests in a second stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,15 @@ jobs:
       name: "Build public site"
     - script: yarn build:app:partners
       name: "Build partners site"
-    - script: yarn test:shared:ui:a11y
-      name: "Storybook a11y testing"
     - script: yarn test:backend:core:testdbsetup && yarn test:backend:core
       name: "Backend unit tests"
     - script: yarn test:e2e:backend:core
       name: "Backend e2e tests"
-    - name: "Cypress tests"
+    - stage: longer tests
+      script: yarn test:shared:ui:a11y
+      name: "Storybook a11y testing"
+    - stage: longer tests
+      name: "Cypress tests"
       script:
         - yarn cypress install
         - yarn db:reseed

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
 
 cache:
   yarn: true
-  directories:
-    - ~/.yarn
-    - ~/.cache
 
 services:
   - redis-server


### PR DESCRIPTION
This way, if the first stage tests fail, the entire run will fail and
free up Travis resources for other PRs. It does add an extra ~6 minutes
of time in the golden case, but will hopefully prevent bottlenecks that
add ~30 minutes to other PRs.

Addresses aspects of #163.