### PR TITLE
Fix the type of amiPercentage(Min|Max)

### DIFF
--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -485,16 +485,16 @@ class Listing extends BaseEntity {
 
   // In the absence of AMI percentage information at the unit level, amiPercentageMin and
   // amiPercentageMax will store the AMI percentage range for the listing as a whole.
-  @Column({ type: "text", nullable: true })
+  @Column({ type: "integer", nullable: true })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
   amiPercentageMin?: number | null
 
-  @Column({ type: "text", nullable: true })
+  @Column({ type: "integer", nullable: true })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
   amiPercentageMax?: number | null
 }
 

--- a/backend/core/src/migration/1628017712683-addListingAndPropertyFields.ts
+++ b/backend/core/src/migration/1628017712683-addListingAndPropertyFields.ts
@@ -10,8 +10,8 @@ export class addListingAndPropertyFields1628017712683 implements MigrationInterf
     await queryRunner.query(`ALTER TABLE "listings" ADD "owner_company" text`)
     await queryRunner.query(`ALTER TABLE "listings" ADD "management_company" text`)
     await queryRunner.query(`ALTER TABLE "listings" ADD "management_website" text`)
-    await queryRunner.query(`ALTER TABLE "listings" ADD "ami_percentage_min" text`)
-    await queryRunner.query(`ALTER TABLE "listings" ADD "ami_percentage_max" text`)
+    await queryRunner.query(`ALTER TABLE "listings" ADD "ami_percentage_min" integer`)
+    await queryRunner.query(`ALTER TABLE "listings" ADD "ami_percentage_max" integer`)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Description

This change corrects the type for `amiPercentageMin` and `amiPercentageMax`; they should be `integer`s, not `text`. https://github.com/CityOfDetroit/bloom/pull/311 erroneously added these fields as strings. Since this is a small change, I've opted to modify the previous DB migration instead of creating a whole new DB migration.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I did two things:

1. Ran `yarn db:reseed` with the new DB migration and inspected the listings table (`\d listings;`) to verify that the type of `ami_percentage_min` and `ami_percentage_max` are `integer`.
2. I temporarily modified `minimal-listing.json` to include an integer for `amiPercentageMin`, and I verified that uploading that listing was successful.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
