### PR TITLE
Hardcode the number of items in listings.e2e-spec.ts.

### DIFF
--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -31,6 +31,8 @@ const argv = yargs.scriptName("seed").options({
   test: { type: "boolean", default: false },
 }).argv
 
+// Note: if changing this list of seeds, you must also change the
+// number in listings.e2e-spec.ts.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const listingSeeds: any[] = [
   ListingDefaultSeed,

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -15,7 +15,6 @@ import { ApplicationMethodsModule } from "../../src/application-methods/applicat
 import { PaperApplicationsModule } from "../../src/paper-applications/paper-applications.module"
 import { ListingEventCreateDto } from "../../src/listings/dto/listing-event.dto"
 import { ListingEventType } from "../../src/listings/types/listing-event-type-enum"
-import { getSeedListingsCount } from "../../src/seed"
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dbOptions = require("../../ormconfig.test")
@@ -52,19 +51,20 @@ describe("Listings", () => {
     // Make the limit 1 less than the full number of listings, so that the first page contains all
     // but the last listing.
     const page = "1"
-    const limit = (getSeedListingsCount() - 1).toString()
-    const params = "/?page=" + page + "&limit=" + limit
+    // This is the number of listings in ../../src/seed.ts minus 1
+    const limit = 9
+    const params = "/?page=" + page + "&limit=" + limit.toString()
     const res = await supertest(app.getHttpServer())
       .get("/listings" + params)
       .expect(200)
-    expect(res.body.items.length).toEqual(getSeedListingsCount() - 1)
+    expect(res.body.items.length).toEqual(limit)
   })
 
   it("should return the last page of paginated listings", async () => {
     // Make the limit 1 less than the full number of listings, so that the second page contains
     // only one listing.
     const page = "2"
-    const limit = (getSeedListingsCount() - 1).toString()
+    const limit = "9"
     const params = "/?page=" + page + "&limit=" + limit
     const res = await supertest(app.getHttpServer())
       .get("/listings" + params)

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -52,6 +52,7 @@ describe("Listings", () => {
     // but the last listing.
     const page = "1"
     // This is the number of listings in ../../src/seed.ts minus 1
+    // TODO(#374): get this number programmatically
     const limit = 9
     const params = "/?page=" + page + "&limit=" + limit.toString()
     const res = await supertest(app.getHttpServer())


### PR DESCRIPTION
# Pull Request Template

## Issue

Closes #369

## Description

Hardcodes the length of the list for the pagination calls to avoid flakiness in the backend e2e tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

backend/core e2e tests were flaky prior to this; after this they were no longer flaky

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
