### PR TITLE
Refactor listings-importer library

### DIFF
--- a/backend/core/scripts/import-listings-from-detroit-arcgis.ts
+++ b/backend/core/scripts/import-listings-from-detroit-arcgis.ts
@@ -1,48 +1,13 @@
-import { importListing } from "./listings-importer"
+import { importListing, createUnitsArray } from "./listings-importer"
 import axios from "axios"
 import { Listing } from "../src/listings/entities/listing.entity"
 import { Property } from "../src/property/entities/property.entity"
 import { Address } from "../src/shared/entities/address.entity"
 import { CountyCode } from "../src/shared/types/county-code"
 import { CSVFormattingType } from "../src/csv/types/csv-formatting-type-enum"
-import { UnitStatus } from "../src/units/types/unit-status-enum"
 
 // Sample usage:
 // $ yarn ts-node scripts/import-listings-from-detroit-arcgis.ts http://localhost:3100 test@example.com:abcdef https://services2.arcgis.com/qvkbeam7Wirps6zC/ArcGIS/rest/services/Affordable_Housing_Website_data_12_20/FeatureServer/0//query
-
-function createUnitsArray(type, number) {
-  const units = []
-  for (let unit_index = 0; unit_index < number; unit_index++) {
-    units.push({
-      unitType: type,
-
-      status: UnitStatus.unknown,
-
-      // This amiPercentage is made up.
-      amiPercentage: "30",
-
-      amiChart: {
-        name: "Fake AMI Chart Name",
-        items: [],
-
-        // Add null id, createdAt, etc. to avoid compilation errors.
-        // (These will be replaced by real values when the script uploads/de-dupes this amiChart.)
-        id: null,
-        createdAt: null,
-        updatedAt: null,
-        units: null,
-      },
-
-      // Add null id, createdAt, etc. to avoid compilation errors.
-      // (These will be replaced by real values when the script uploads this unit.)
-      id: null,
-      createdAt: null,
-      updatedAt: null,
-      property: null,
-    })
-  }
-  return units
-}
 
 async function main() {
   if (process.argv.length < 5) {

--- a/backend/core/scripts/listings-importer.ts
+++ b/backend/core/scripts/listings-importer.ts
@@ -12,7 +12,6 @@ export function createUnitsArray(type: string, number: number) {
   for (let unit_index = 0; unit_index < number; unit_index++) {
     units.push({
       unitType: type,
-
       status: UnitStatus.unknown,
     })
   }

--- a/backend/core/scripts/listings-importer.ts
+++ b/backend/core/scripts/listings-importer.ts
@@ -14,30 +14,6 @@ export function createUnitsArray(type: string, number: number) {
       unitType: type,
 
       status: UnitStatus.unknown,
-
-      /*
-      // This amiPercentage is made up.
-      amiPercentage: "30",
-
-      amiChart: {
-        name: "Fake AMI Chart Name",
-        items: [],
-
-        // Add null id, createdAt, etc. to avoid compilation errors.
-        // (These will be replaced by real values when the script uploads/de-dupes this amiChart.)
-        id: null,
-        createdAt: null,
-        updatedAt: null,
-        units: null,
-      },
-
-      // Add null id, createdAt, etc. to avoid compilation errors.
-      // (These will be replaced by real values when the script uploads this unit.)
-      id: null,
-      createdAt: null,
-      updatedAt: null,
-      property: null,
-      */
     })
   }
   return units
@@ -65,9 +41,7 @@ async function uploadListing(listing: ListingCreate) {
       body: listing,
     })
   } catch (e) {
-    console.log(listing)
-    console.log(e.response.data.message)
-    process.exit(1)
+    throw new Error(e.response.data.message)
   }
 }
 

--- a/backend/core/scripts/listings-importer.ts
+++ b/backend/core/scripts/listings-importer.ts
@@ -2,9 +2,46 @@ import * as client from "../types/src/backend-swagger"
 import axios from "axios"
 import { ListingCreate, serviceOptions } from "../types/src/backend-swagger"
 import { ListingStatus } from "../src/listings/types/listing-status-enum"
+import { UnitStatus } from "../src/units/types/unit-status-enum"
 
 // NOTE: This script relies on any logged-in users having permission to create
 // listings and properties (defined in backend/core/src/auth/authz_policy.csv)
+
+export function createUnitsArray(type: string, number: number) {
+  const units = []
+  for (let unit_index = 0; unit_index < number; unit_index++) {
+    units.push({
+      unitType: type,
+
+      status: UnitStatus.unknown,
+
+      /*
+      // This amiPercentage is made up.
+      amiPercentage: "30",
+
+      amiChart: {
+        name: "Fake AMI Chart Name",
+        items: [],
+
+        // Add null id, createdAt, etc. to avoid compilation errors.
+        // (These will be replaced by real values when the script uploads/de-dupes this amiChart.)
+        id: null,
+        createdAt: null,
+        updatedAt: null,
+        units: null,
+      },
+
+      // Add null id, createdAt, etc. to avoid compilation errors.
+      // (These will be replaced by real values when the script uploads this unit.)
+      id: null,
+      createdAt: null,
+      updatedAt: null,
+      property: null,
+      */
+    })
+  }
+  return units
+}
 
 function uploadPreferences(listing) {
   const preferencesService = new client.PreferencesService()

--- a/backend/core/src/migration/1625825502154-refactor-unit-types-rent-types-and-priority-types.ts
+++ b/backend/core/src/migration/1625825502154-refactor-unit-types-rent-types-and-priority-types.ts
@@ -12,7 +12,7 @@ export class refactorUnitTypesRentTypesAndPriorityTypes1625825502154 implements 
       `ALTER TABLE "units" ADD CONSTRAINT "FK_1e193f5ffdda908517e47d4e021" FOREIGN KEY ("unit_type_id") REFERENCES "unit_types"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
     )
 
-    const unitTypeSeeds = ["studio", "oneBdrm", "twoBdrm", "threeBdrm", "fourBdrm", "fiveBdrm"]
+    const unitTypeSeeds = ["studio", "oneBdrm", "twoBdrm", "threeBdrm", "fourBdrm"]
     const existingUnitTypes = (await queryRunner.query(`SELECT DISTINCT unit_type FROM units`)).map(
       (result) => result.unit_type
     )

--- a/backend/core/src/migration/1625825502154-refactor-unit-types-rent-types-and-priority-types.ts
+++ b/backend/core/src/migration/1625825502154-refactor-unit-types-rent-types-and-priority-types.ts
@@ -12,7 +12,7 @@ export class refactorUnitTypesRentTypesAndPriorityTypes1625825502154 implements 
       `ALTER TABLE "units" ADD CONSTRAINT "FK_1e193f5ffdda908517e47d4e021" FOREIGN KEY ("unit_type_id") REFERENCES "unit_types"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
     )
 
-    const unitTypeSeeds = ["studio", "oneBdrm", "twoBdrm", "threeBdrm", "fourBdrm"]
+    const unitTypeSeeds = ["studio", "oneBdrm", "twoBdrm", "threeBdrm", "fourBdrm", "fiveBdrm"]
     const existingUnitTypes = (await queryRunner.query(`SELECT DISTINCT unit_type FROM units`)).map(
       (result) => result.unit_type
     )


### PR DESCRIPTION
This change pulls the `createUnitsArray` function out of the "read from ArcGIS" script and into the `listings-importer.ts` library, so that it can be reused for the forthcoming "import from CSV" script. It also removes the fake values it set for fields like `units.amiPercentage` and `units.amiChart` (which were previously required).

This change also changes `uploadListing` to pass a sanitized error message up, rather than killing the process itself. Pushing the error-handling responsibility to the callers allows them to decide whether they'd like to continue uploading more listings even if one fails.