### PR TITLE
Fix the flakiness in the backend e2e test.

### DIFF
--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -76,7 +76,7 @@ describe("Listings", () => {
   // TODO: replace jsonpath with SQL-level filtering
   it("should return only the specified listings", async () => {
     const query =
-      "/?jsonpath=%24%5B%3F%28%40.applicationAddress.city%3D%3D%22Foster%20City%22%29%5D"
+      "/?limit=all&jsonpath=%24%5B%3F%28%40.applicationAddress.city%3D%3D%22Foster%20City%22%29%5D"
     const res = await supertest(app.getHttpServer()).get(`/listings${query}`).expect(200)
     expect(res.body.items.length).toEqual(1)
     expect(res.body.items[0].applicationAddress.city).toEqual("Foster City")
@@ -84,14 +84,15 @@ describe("Listings", () => {
 
   // TODO: replace jsonpath with SQL-level filtering
   it("shouldn't return any listings for incorrect query", async () => {
-    const query = "/?jsonpath=%24%5B%3F(%40.applicationNONSENSE.argh%3D%3D%22San+Jose%22)%5D"
+    const query =
+      "/?limit=all&jsonpath=%24%5B%3F(%40.applicationNONSENSE.argh%3D%3D%22San+Jose%22)%5D"
     const res = await supertest(app.getHttpServer()).get(`/listings${query}`).expect(200)
     expect(res.body.items.length).toEqual(0)
   })
 
   // TODO: replace jsonpath with SQL-level filtering
   it("should return only active listings", async () => {
-    const query = "/?jsonpath=%24%5B%3F%28%40.status%3D%3D%22active%22%29%5D"
+    const query = "/?limit=all&jsonpath=%24%5B%3F%28%40.status%3D%3D%22active%22%29%5D"
     const res = await supertest(app.getHttpServer()).get(`/listings${query}`).expect(200)
     expect(res.body.items.map((listing) => listing.id).length).toBeGreaterThan(0)
   })


### PR DESCRIPTION
Removes the randomness associated with the default pagination limit of 10 items, since we now have 12 items in the seeds.