### PR TITLE
Add zipcode filtering capability to the backend.

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -810,4 +810,5 @@ export const filterTypeToFieldMap: Record<keyof typeof ListingFilterKeys, string
   name: "listings.name",
   neighborhood: "property.neighborhood",
   bedrooms: "unitTypeRef.num_bedrooms",
+  zipcode: "buildingAddress.zipCode",
 }

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -58,6 +58,7 @@ export class ListingsService {
       .leftJoin("listings.property", "property")
       .leftJoin("property.units", "units")
       .leftJoin("units.unitType", "unitTypeRef")
+      .leftJoin("property.buildingAddress", "buildingAddress")
       .groupBy("listings.id")
       .orderBy({ "listings.id": "DESC" })
 

--- a/backend/core/src/listings/types/listing-filter-keys-enum.ts
+++ b/backend/core/src/listings/types/listing-filter-keys-enum.ts
@@ -4,4 +4,5 @@ export enum ListingFilterKeys {
   name = "name",
   neighborhood = "neighborhood",
   bedrooms = "bedrooms",
+  zipcode = "zipcode",
 }

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -97,6 +97,12 @@ describe("Listings", () => {
     expect(res.body.items.map((listing) => listing.id).length).toBeGreaterThan(0)
   })
 
+  it("should return listings with matching zipcodes", async () => {
+    const query = "/?limit=all&filter[$comparison]=IN&filter[zipcode]=48211,48201"
+    const res = await supertest(app.getHttpServer()).get(`/listings${query}`).expect(200)
+    expect(res.body.items.length).toBeGreaterThanOrEqual(2)
+  })
+
   it("should modify property related fields of a listing and return a modified value", async () => {
     const res = await supertest(app.getHttpServer()).get("/listings").expect(200)
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #321

This change addresses only certain aspects of the issue

## Description

Adds the zipcode filter type and joins the inner query with the address to enable filtering on it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Run a query against the backend such as `http://localhost:3100/listings?limit=all&filter[$comparison]=IN&filter[zipcode]=48211,48201` and see 3 results. No frontend changes in this PR.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
