### PR TITLE
Create Units Summary table from seeds

### DIFF
--- a/backend/core/src/seeder/seeder.module.ts
+++ b/backend/core/src/seeder/seeder.module.ts
@@ -38,6 +38,7 @@ import { Listing10157Seed } from "../seeds/listings/listing-detroit-10157"
 import { Listing10147Seed } from "../seeds/listings/listing-detroit-10147"
 import { Listing10145Seed } from "../seeds/listings/listing-detroit-10145"
 import { ListingTreymoreSeed } from "../seeds/listings/listing-detroit-treymore"
+import { UnitsSummary } from "../units-summary/entities/units-summary.entity"
 
 @Module({})
 export class SeederModule {
@@ -61,6 +62,7 @@ export class SeederModule {
           AmiChart,
           Property,
           Unit,
+          UnitsSummary,
           User,
           ApplicationMethod,
           PaperApplication,

--- a/backend/core/src/seeds/listings/listing-default-seed.ts
+++ b/backend/core/src/seeds/listings/listing-default-seed.ts
@@ -8,6 +8,7 @@ import { ReservedCommunityType } from "../../reserved-community-type/entities/re
 import { AmiChart } from "../../ami-charts/entities/ami-chart.entity"
 import { Property } from "../../property/entities/property.entity"
 import { Unit } from "../../units/entities/unit.entity"
+import { UnitsSummary } from "../../units-summary/entities/units-summary.entity"
 import { User } from "../../auth/entities/user.entity"
 import { UnitCreateDto } from "../../units/dto/unit.dto"
 import {
@@ -36,6 +37,8 @@ export class ListingDefaultSeed {
     @InjectRepository(AmiChart) protected readonly amiChartRepository: Repository<AmiChart>,
     @InjectRepository(Property) protected readonly propertyRepository: Repository<Property>,
     @InjectRepository(Unit) protected readonly unitsRepository: Repository<Unit>,
+    @InjectRepository(UnitsSummary)
+    protected readonly unitsSummaryRepository: Repository<UnitsSummary>,
     @InjectRepository(User) protected readonly userRepository: Repository<User>,
     @InjectRepository(ApplicationMethod)
     protected readonly applicationMethodRepository: Repository<ApplicationMethod>

--- a/backend/core/src/seeds/listings/listing-detroit-10145.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10145.ts
@@ -160,39 +160,4 @@ export class Listing10145Seed extends ListingDefaultSeed {
 
     return await this.listingRepository.save(listingCreateDto)
   }
-
-  /**
-   
-  forEach(listingCreateDto) => { ... } )
-
-
-
-  UnitsSummaryDto extends OmitType(UnitsSummary, [] as const) {}
-
-  add unit summary details here
-    For each Property.UnitType
-       create units-summary DTO
-    
-
-    
-  unitType: this.Property.UnitType
-  property: this.Property
-  monthlyRent: string
-
-  monthlyRentAsPercentOfIncome?: string | null
-  amiPercentage?: string | null
-  minimumIncomeMin?: string | null
-  minimumIncomeMax?: string | null
-  maxOccupancy?: number | null
-  minOccupancy?: number | null
-  floorMin?: number | null
-  floorMax?: number | null
-  sqFeetMin?: string | null
-  sqFeetMax?: string | null
-  priorityType?: UnitAccessibilityPriorityType | null
-  totalCount?: number | null
-  totalAvailable?: number | null
-
-
-   */
 }

--- a/backend/core/src/seeds/listings/listing-detroit-10145.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10145.ts
@@ -10,6 +10,7 @@ import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 import { ApplicationMethod } from "../../application-methods/entities/application-method.entity"
 import assert from "assert"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
 
 const mcvProperty: PropertySeedType = {
   buildingAddress: {
@@ -129,6 +130,69 @@ export class Listing10145Seed extends ListingDefaultSeed {
       reservedCommunityDescription: "",
     }
 
+    const mcvUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeOneBdrm,
+      totalCount: 28,
+      monthlyRent: "$0",
+      property: property,
+    }
+    mcvUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
+
+    const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeTwoBdrm,
+      totalCount: 142,
+      monthlyRent: "$0",
+      property: property,
+    }
+    mcvUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
+
+    const threeBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeThreeBdrm,
+      totalCount: 24,
+      monthlyRent: "$0",
+      property: property,
+    }
+    mcvUnitsSummaryToBeCreated.push(threeBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(mcvUnitsSummaryToBeCreated)
+
     return await this.listingRepository.save(listingCreateDto)
   }
+
+  /**
+   
+  forEach(listingCreateDto) => { ... } )
+
+
+
+  UnitsSummaryDto extends OmitType(UnitsSummary, [] as const) {}
+
+  add unit summary details here
+    For each Property.UnitType
+       create units-summary DTO
+    
+
+    
+  unitType: this.Property.UnitType
+  property: this.Property
+  monthlyRent: string
+
+  monthlyRentAsPercentOfIncome?: string | null
+  amiPercentage?: string | null
+  minimumIncomeMin?: string | null
+  minimumIncomeMax?: string | null
+  maxOccupancy?: number | null
+  minOccupancy?: number | null
+  floorMin?: number | null
+  floorMax?: number | null
+  sqFeetMin?: string | null
+  sqFeetMax?: string | null
+  priorityType?: UnitAccessibilityPriorityType | null
+  totalCount?: number | null
+  totalAvailable?: number | null
+
+
+   */
 }

--- a/backend/core/src/seeds/listings/listing-detroit-10147.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10147.ts
@@ -10,6 +10,7 @@ import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 import { ApplicationMethod } from "../../application-methods/entities/application-method.entity"
 import assert from "assert"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
 
 const mshProperty: PropertySeedType = {
   buildingAddress: {
@@ -117,6 +118,26 @@ export class Listing10147Seed extends ListingDefaultSeed {
       property: property,
       preferences: [],
     }
+
+    const mshUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const fourBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeFourBdrm,
+      totalCount: 15,
+      monthlyRent: "$0",
+      property: property,
+    }
+    mshUnitsSummaryToBeCreated.push(fourBdrmUnitsSummary)
+
+    const threeBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeThreeBdrm,
+      totalCount: 9,
+      monthlyRent: "$0",
+      property: property,
+    }
+    mshUnitsSummaryToBeCreated.push(threeBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(mshUnitsSummaryToBeCreated)
 
     return await this.listingRepository.save(listingCreateDto)
   }

--- a/backend/core/src/seeds/listings/listing-detroit-10157.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10157.ts
@@ -9,6 +9,7 @@ import { BaseEntity, DeepPartial } from "typeorm"
 import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 import { ApplicationMethod } from "../../application-methods/entities/application-method.entity"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
 
 const nccProperty: PropertySeedType = {
   // See http://rentlinx.kmgprestige.com/640-Delaware-Street-Detroit-MI-48202
@@ -176,6 +177,34 @@ export class Listing10157Seed extends ListingDefaultSeed {
       property: property,
       preferences: [],
     }
+
+    const nccUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const zeroBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeStudio,
+      totalCount: 10,
+      monthlyRent: "$0",
+      property: property,
+    }
+    nccUnitsSummaryToBeCreated.push(zeroBdrmUnitsSummary)
+
+    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeOneBdrm,
+      totalCount: 20,
+      monthlyRent: "$0",
+      property: property,
+    }
+    nccUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
+
+    const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeTwoBdrm,
+      totalCount: 10,
+      monthlyRent: "$0",
+      property: property,
+    }
+    nccUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(nccUnitsSummaryToBeCreated)
 
     return await this.listingRepository.save(listingCreateDto)
   }

--- a/backend/core/src/seeds/listings/listing-detroit-10157.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10157.ts
@@ -182,25 +182,30 @@ export class Listing10157Seed extends ListingDefaultSeed {
 
     const zeroBdrmUnitsSummary: UnitsSummaryCreateDto = {
       unitType: unitTypeStudio,
-      totalCount: 10,
-      monthlyRent: "$0",
+      totalCount: 1,
+      monthlyRent: "$470",
       property: property,
+      sqFeetMax: "550",
     }
     nccUnitsSummaryToBeCreated.push(zeroBdrmUnitsSummary)
 
     const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
       unitType: unitTypeOneBdrm,
-      totalCount: 20,
-      monthlyRent: "$0",
+      totalCount: 2,
+      monthlyRent: "$650",
       property: property,
+      sqFeetMin: "800",
+      sqFeetMax: "1000",
     }
     nccUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
 
     const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
       unitType: unitTypeTwoBdrm,
-      totalCount: 10,
-      monthlyRent: "$0",
+      totalCount: 2,
+      monthlyRent: "$750",
       property: property,
+      sqFeetMin: "900",
+      sqFeetMax: "1100",
     }
     nccUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
 

--- a/backend/core/src/seeds/listings/listing-detroit-10158.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10158.ts
@@ -127,6 +127,14 @@ export class Listing10158Seed extends ListingDefaultSeed {
 
     const ncpUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
 
+    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeOneBdrm,
+      totalCount: 40,
+      monthlyRent: "$0",
+      property: property,
+    }
+    ncpUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
+
     const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
       unitType: unitTypeTwoBdrm,
       totalCount: 36,

--- a/backend/core/src/seeds/listings/listing-detroit-10158.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10158.ts
@@ -9,6 +9,7 @@ import { UnitCreateDto } from "../../units/dto/unit.dto"
 import { BaseEntity, DeepPartial } from "typeorm"
 import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
 
 const ncpProperty: PropertySeedType = {
   amenities: "Parking, Elevator in Building",
@@ -123,6 +124,18 @@ export class Listing10158Seed extends ListingDefaultSeed {
       property: property,
       preferences: [],
     }
+
+    const ncpUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeTwoBdrm,
+      totalCount: 36,
+      monthlyRent: "$0",
+      property: property,
+    }
+    ncpUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(ncpUnitsSummaryToBeCreated)
 
     return await this.listingRepository.save(listingCreateDto)
   }

--- a/backend/core/src/seeds/listings/listing-detroit-treymore.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-treymore.ts
@@ -157,27 +157,13 @@ export class ListingTreymoreSeed extends ListingDefaultSeed {
 
     const treymoreUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
 
-    const zeroBdrmUnitsSummary: UnitsSummaryCreateDto = {
-      unitType: unitTypeStudio,
-      totalCount: 1,
-      monthlyRent: "$0",
-      property: property,
-    }
-    treymoreUnitsSummaryToBeCreated.push(zeroBdrmUnitsSummary)
-
-    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
-      unitType: unitTypeOneBdrm,
-      totalCount: 1,
-      monthlyRent: "$0",
-      property: property,
-    }
-    treymoreUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
-
     const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
       unitType: unitTypeTwoBdrm,
       totalCount: 4,
-      monthlyRent: "$0",
+      monthlyRent: "$707",
       property: property,
+      sqFeetMin: "720",
+      sqFeetMax: "1003",
     }
     treymoreUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
 

--- a/backend/core/src/seeds/listings/listing-detroit-treymore.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-treymore.ts
@@ -9,6 +9,7 @@ import { BaseEntity, DeepPartial } from "typeorm"
 import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 import { ApplicationMethod } from "../../application-methods/entities/application-method.entity"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
 
 const treymoreProperty: PropertySeedType = {
   // See http://rentlinx.kmgprestige.com/457-Brainard-Street-Detroit-MI-48201
@@ -153,6 +154,34 @@ export class ListingTreymoreSeed extends ListingDefaultSeed {
       property: property,
       preferences: [],
     }
+
+    const treymoreUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const zeroBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeStudio,
+      totalCount: 1,
+      monthlyRent: "$0",
+      property: property,
+    }
+    treymoreUnitsSummaryToBeCreated.push(zeroBdrmUnitsSummary)
+
+    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeOneBdrm,
+      totalCount: 1,
+      monthlyRent: "$0",
+      property: property,
+    }
+    treymoreUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
+
+    const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeTwoBdrm,
+      totalCount: 4,
+      monthlyRent: "$0",
+      property: property,
+    }
+    treymoreUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(treymoreUnitsSummaryToBeCreated)
 
     return await this.listingRepository.save(listingCreateDto)
   }


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #380 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Creates UnitsSummaryDTOs from the seed files and populates the unit_summary table. Note the monthly rent field is currently a placeholder of $0.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Run your local version and do a db:reseed.  Then open the unit_summary table with `psql bloom` and see that it is populated with data. You should see 12 rows based on the seeded data.

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
