### PR TITLE
Hide sections and display warning if no features data is available

### DIFF
--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailApplicationAddress.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailApplicationAddress.tsx
@@ -14,6 +14,8 @@ const DetailApplicationAddress = () => {
       return t("application.contact.mailingAddress")
   }
 
+  if (!listing.leasingAgentAddress) return <></>
+
   return (
     <GridSection
       className="bg-primary-lighter"

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
@@ -18,6 +18,8 @@ const DetailListingPhoto = () => {
   if (listing.image == null && listing.assets.length > 0) {
     listingFormPhoto = listing.assets.find((asset) => asset.label == "building")
   }
+  if (!listingFormPhoto) return <></>
+
   const listingPhotoUrl = /https?:\/\//.exec(listingFormPhoto.fileId)
     ? listingFormPhoto.fileId
     : cloudinaryUrlFromId(listingFormPhoto.fileId)

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -139,6 +139,21 @@ export const ListingView = (props: ListingProps) => {
     } else return t("listings.reservedCommunityTitleDefault")
   }
 
+  const shouldShowFeaturesDetail = () => {
+    return (
+      listing.neighborhood ||
+      listing.yearBuilt ||
+      listing.smokingPolicy ||
+      listing.petPolicy ||
+      listing.amenities ||
+      listing.unitAmenities ||
+      listing.servicesOffered ||
+      listing.accessibility ||
+      (listing.units && listing.units.length > 0) ||
+      listing.unitsSummarized
+    )
+  }
+
   return (
     <article className="flex flex-wrap relative max-w-5xl m-auto">
       <header className="image-card--leader">
@@ -317,45 +332,52 @@ export const ListingView = (props: ListingProps) => {
           title={t("listings.sections.featuresTitle")}
           subtitle={t("listings.sections.featuresSubtitle")}
         >
-          <div className="listing-detail-panel">
-            <dl className="column-definition-list">
-              {listing.neighborhood && (
-                <Description term={t("t.neighborhood")} description={listing.neighborhood} />
-              )}
-              {listing.yearBuilt && (
-                <Description term={t("t.built")} description={listing.yearBuilt} />
-              )}
-              {listing.smokingPolicy && (
-                <Description term={t("t.smokingPolicy")} description={listing.smokingPolicy} />
-              )}
-              {listing.petPolicy && (
-                <Description term={t("t.petsPolicy")} description={listing.petPolicy} />
-              )}
-              {listing.amenities && (
-                <Description term={t("t.propertyAmenities")} description={listing.amenities} />
-              )}
-              {listing.unitAmenities && (
-                <Description term={t("t.unitAmenities")} description={listing.unitAmenities} />
-              )}
-              {listing.servicesOffered && (
-                <Description term={t("t.servicesOffered")} description={listing.servicesOffered} />
-              )}
-              {listing.accessibility && (
-                <Description term={t("t.accessibility")} description={listing.accessibility} />
-              )}
-              <Description
-                term={t("t.unitFeatures")}
-                description={
-                  <UnitTables
-                    units={listing.units}
-                    unitSummaries={listing?.unitsSummarized?.byUnitType}
-                    disableAccordion={listing.disableUnitsAccordion}
+          {!shouldShowFeaturesDetail() ? (
+            t("errors.noData")
+          ) : (
+            <div className="listing-detail-panel">
+              <dl className="column-definition-list">
+                {listing.neighborhood && (
+                  <Description term={t("t.neighborhood")} description={listing.neighborhood} />
+                )}
+                {listing.yearBuilt && (
+                  <Description term={t("t.built")} description={listing.yearBuilt} />
+                )}
+                {listing.smokingPolicy && (
+                  <Description term={t("t.smokingPolicy")} description={listing.smokingPolicy} />
+                )}
+                {listing.petPolicy && (
+                  <Description term={t("t.petsPolicy")} description={listing.petPolicy} />
+                )}
+                {listing.amenities && (
+                  <Description term={t("t.propertyAmenities")} description={listing.amenities} />
+                )}
+                {listing.unitAmenities && (
+                  <Description term={t("t.unitAmenities")} description={listing.unitAmenities} />
+                )}
+                {listing.servicesOffered && (
+                  <Description
+                    term={t("t.servicesOffered")}
+                    description={listing.servicesOffered}
                   />
-                }
-              />
-            </dl>
-            <AdditionalFees listing={listing} />
-          </div>
+                )}
+                {listing.accessibility && (
+                  <Description term={t("t.accessibility")} description={listing.accessibility} />
+                )}
+                <Description
+                  term={t("t.unitFeatures")}
+                  description={
+                    <UnitTables
+                      units={listing.units}
+                      unitSummaries={listing?.unitsSummarized?.byUnitType}
+                      disableAccordion={listing.disableUnitsAccordion}
+                    />
+                  }
+                />
+              </dl>
+              <AdditionalFees listing={listing} />
+            </div>
+          )}
         </ListingDetailItem>
 
         <ListingDetailItem

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -149,8 +149,14 @@ export const ListingView = (props: ListingProps) => {
       listing.unitAmenities ||
       listing.servicesOffered ||
       listing.accessibility ||
+      // props for UnitTables
       (listing.units && listing.units.length > 0) ||
-      listing.unitsSummarized
+      listing.unitsSummarized ||
+      // props for AdditionalFees
+      listing.depositMin ||
+      listing.depositMax ||
+      listing.applicationFee ||
+      listing.costsNotIncluded
     )
   }
 

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -679,7 +679,8 @@
         "householdTooSmall": "حجم أسرتك صغير جدًا.",
         "dateError": "ارجوك ادخل تاريخ صحيح",
         "rateLimitExceeded": "تم تجاوز حد المعدل ، حاول مرة أخرى لاحقًا.",
-        "requiredFieldError": "هذه الخانة مطلوبه."
+        "requiredFieldError": "هذه الخانة مطلوبه.",
+        "noData": "لا تتوافر بيانات"
     },
     "footer": {
         "contact": "اتصال",

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -679,7 +679,8 @@
         "householdTooSmall": "আপনার পরিবারের আকার খুব ছোট।",
         "dateError": "একটি বৈধ তারিখ লিখুন দয়া করে",
         "rateLimitExceeded": "রেটের সীমা অতিক্রম করেছে, পরে আবার চেষ্টা করুন।",
-        "requiredFieldError": "ঘরটি অবশ্যই পূরণ করতে হবে."
+        "requiredFieldError": "ঘরটি অবশ্যই পূরণ করতে হবে.",
+        "noData": "কোন তথ্য নেই."
     },
     "footer": {
         "contact": "যোগাযোগ",

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -679,7 +679,8 @@
         "householdTooSmall": "El tamaño de su hogar es demasiado pequeño.",
         "dateError": "Por favor introduzca una fecha valida",
         "rateLimitExceeded": "Se superó el límite de frecuencia. Vuelve a intentarlo más tarde.",
-        "requiredFieldError": "Este campo es requerido."
+        "requiredFieldError": "Este campo es requerido.",
+        "noData": "Datos no disponibles"
     },
     "footer": {
         "contact": "Contacto",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -680,7 +680,8 @@
     "householdTooSmall": "Your household size is too small.",
     "dateError": "Please enter a valid date",
     "rateLimitExceeded": "Rate limit exceeded, try again later.",
-    "requiredFieldError": "This field is required."
+    "requiredFieldError": "This field is required.",
+    "noData": "No data available."
   },
   "footer": {
     "contact": "Contact",

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -396,7 +396,8 @@
     "selectAnOption": "Vui lòng chọn một lựa chọn.",
     "selectOption": "Vui lòng chọn một trong các lựa chọn ở trên.",
     "householdTooBig": "Quy mô hộ gia đình của quý vị quá lớn.",
-    "householdTooSmall": "Quy mô hộ gia đình của quý vị quá nhỏ."
+    "householdTooSmall": "Quy mô hộ gia đình của quý vị quá nhỏ.",
+    "noData": "Không có dữ liệu."
   },
   "footer": {
     "contact": "Liên lạc",

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -396,7 +396,8 @@
     "selectAnOption": "請選擇一個選項。",
     "selectOption": "請選擇以上其中一個選項。",
     "householdTooBig": "您的家庭人數過多。",
-    "householdTooSmall": "您的家庭人數過少。"
+    "householdTooSmall": "您的家庭人數過少。",
+    "noData": "沒有可用數據"
   },
   "footer": {
     "contact": "聯絡方式",


### PR DESCRIPTION
## Issue

Addresses #330 

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Verifies that the listing has any "Features" data. If not, displays a warning that no data is available. E.g:

![image](https://user-images.githubusercontent.com/83078310/129971050-a77cbe9b-cbbc-4ce7-b238-f30518a7e420.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I manually deleted data from the seeded DB so there were no units or feature information and verified that the warning was displayed and no sections were visible (see photo above).

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
