### PR TITLE
Enable closing filter modal.

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -99,8 +99,7 @@ const ListingsPage = () => {
       <Modal
         open={filterModalVisible}
         title={t("listingFilters.modalTitle")}
-        actions={[]}
-        hideCloseIcon
+        onClose={() => setFilterModalVisible(false)}
       >
         <Form onSubmit={handleSubmit(onSubmit)}>
           <div className="form-card__group">
@@ -141,12 +140,9 @@ const ListingsPage = () => {
             />
           </div>
           <div className="text-center mt-6">
-            <Button styleType={AppearanceStyleType.primary}>Apply Filters</Button>
-          </div>
-          <div className="text-center mt-6">
-            <a href="#" onClick={() => setFilterModalVisible(false)}>
-              {t("t.cancel")}
-            </a>
+            <Button type="submit" styleType={AppearanceStyleType.primary}>
+              Apply Filters
+            </Button>
           </div>
         </Form>
       </Modal>

--- a/ui-components/src/overlays/Modal.tsx
+++ b/ui-components/src/overlays/Modal.tsx
@@ -6,7 +6,7 @@ import { Overlay, OverlayProps } from "./Overlay"
 
 export interface ModalProps extends Omit<OverlayProps, "children"> {
   title: string
-  actions: React.ReactNode[]
+  actions?: React.ReactNode[]
   hideCloseIcon?: boolean
   children?: React.ReactNode
 }
@@ -48,7 +48,7 @@ export const Modal = (props: ModalProps) => {
           )}
         </section>
 
-        <ModalFooter actions={props.actions} />
+        {props.actions && <ModalFooter actions={props.actions} />}
 
         {!props.hideCloseIcon && (
           <button className="modal__close" aria-label="Close" onClick={props.onClose} tabIndex={0}>


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #412

- [x] This change addresses only certain aspects of the issue

## Description

Enables the close button and clicking outside the modal to close it.
Also removes the footer that doesn't contain anything in it. This will
help bring the filter modal closer to the mocks and enable a workaround
for #412.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

View the filter modal and click outside the window or the `x` to see that it closes.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
