### PR TITLE
Constrain the height of the `Modal` component, and make it scrollable if it overflows

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -37,3 +37,10 @@ a.button.is-primary:hover {
   @apply bg-primary-light;
   @apply text-black;
 }
+
+// Constrain the height of modals to 80% of the viewport
+// and make them scrollable once that is exceeded.
+.modal {
+  max-height: 80vh;
+  overflow-y: auto;
+}

--- a/ui-components/src/overlays/Modal.scss
+++ b/ui-components/src/overlays/Modal.scss
@@ -9,8 +9,6 @@
   @apply rounded-md;
   @apply shadow-md;
   min-width: 25rem;
-  max-height: 80vh;
-  overflow-y: auto;
 }
 
 // Content containers

--- a/ui-components/src/overlays/Modal.scss
+++ b/ui-components/src/overlays/Modal.scss
@@ -9,6 +9,8 @@
   @apply rounded-md;
   @apply shadow-md;
   min-width: 25rem;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 // Content containers


### PR DESCRIPTION
## Issue

Closes #412 

- [X] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This change sets the max height of all modals to 80% of the viewport height. And if the modal's height exceeds that max height, it makes it so that the user can scroll up and down within the modal.

Filter modal on desktop view:

![image](https://user-images.githubusercontent.com/8754454/130137583-10a573d9-c294-4004-8479-40f15c1e4f88.png)

Filter modal on mobile view:

![image](https://user-images.githubusercontent.com/8754454/130137606-77bdc262-863d-4898-b1ed-93b5ebe8fe4f.png)

Note: I chose 80% of the viewport height instead of 100% because it "felt right" for the modal to not occupy the entire vertical height of the viewport. If anyone has a more evidence-based way to make this decision, please let me know 😅 

Another note: this will affect all views that use the `Modal` React component. I believe the filter modal is the tallest, though, and so is the most likely to run into these max height limits.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I looked at the filter modal in the `/listings` view in both:
- [X] Desktop View
- [X] Mobile View

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
