### PR TITLE
Remove the /listings query from the public front page.

### DIFF
--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react"
 import Head from "next/head"
-import { Listing } from "@bloom-housing/backend-core/types"
 import {
   AlertBox,
   LinkButton,
@@ -10,15 +9,10 @@ import {
   SiteAlert,
 } from "@bloom-housing/ui-components"
 import Layout from "../layouts/application"
-import axios from "axios"
 import { ConfirmationModal } from "../src/ConfirmationModal"
 import { MetaTags } from "../src/MetaTags"
 
-interface IndexProps {
-  listings: Listing[]
-}
-
-export default function Home(props: IndexProps) {
+export default function Home() {
   const blankAlertInfo = {
     alertMessage: null,
     alertType: null,
@@ -75,20 +69,4 @@ export default function Home(props: IndexProps) {
       />
     </Layout>
   )
-}
-
-export async function getStaticProps() {
-  let listings = []
-  try {
-    // const response = await axios.get(process.env.listingServiceUrl)
-    const response = await axios.get(
-      process.env.listingServiceUrl +
-        "?view=base&limit=all&filter[$comparison]=<>&filter[status]=pending"
-    )
-    listings = response?.data?.items ? response.data.items : []
-  } catch (error) {
-    console.error(error)
-  }
-
-  return { props: { listings }, revalidate: process.env.cacheRevalidate }
 }

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -188,7 +188,7 @@ const ListingsPage = () => {
             totalPages={listingsData?.meta.totalPages}
             currentPage={currentPage}
             itemsPerPage={itemsPerPage}
-            quantityLabel={t("applications.totalApplications")}
+            quantityLabel={t("listings.totalListings")}
             setCurrentPage={setQueryString}
           />
         </div>


### PR DESCRIPTION
## Issue

- Closes #179

## Description

Remove the static props that are unused from the page, since on dev builds it will generate those every page load, which slows down the front page load.

Also changes the text on the listings page from "Total Applications" to "Total Listings".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Passing tests, load the front page in a dev build and notice that it's faster.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
