### PR TITLE
158/remove application references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file. The format 
 - Removed:
   - Eligibility section of detailed listing view
     ([#422](https://github.com/CityOfDetroit/bloom/pull/422))
+  - Application section of partner portal
+    ([#438](https://github.com/CityOfDetroit/bloom/pull/438))
 
 ## Detroit Team M9
 

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -165,10 +165,12 @@ async function seed() {
 
   for (let i = 0; i < 10; i++) {
     for (const listing of listings) {
-      await Promise.all([
-        await makeNewApplication(app, listing, user1),
-        await makeNewApplication(app, listing, user2),
-      ])
+      if (listing.countyCode !== CountyCode.detroit) {
+        await Promise.all([
+          await makeNewApplication(app, listing, user1),
+          await makeNewApplication(app, listing, user2),
+        ])
+      }
     }
   }
 

--- a/sites/partners/pages/index.tsx
+++ b/sites/partners/pages/index.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   LocalizedLink,
 } from "@bloom-housing/ui-components"
-import moment from "moment"
 import { Listing } from "@bloom-housing/backend-core/types"
 import { AgGridReact } from "ag-grid-react"
 import { GridOptions } from "ag-grid-community"
@@ -16,7 +15,6 @@ import { GridOptions } from "ag-grid-community"
 import { useListingsData } from "../lib/hooks"
 import Layout from "../layouts"
 import { MetaTags } from "../src/MetaTags"
-import { Router, useRouter } from "next/router"
 
 export default function ListingsList() {
   const { profile } = useContext(AuthContext)

--- a/sites/partners/pages/index.tsx
+++ b/sites/partners/pages/index.tsx
@@ -83,7 +83,8 @@ export default function ListingsList() {
       {
         headerName: t("listings.listingName"),
         field: "name",
-        sortable: false,
+        sortable: true,
+        sort: "asc",
         filter: false,
         resizable: true,
         cellRenderer: "ListingsLink",
@@ -101,17 +102,10 @@ export default function ListingsList() {
       {
         headerName: t("listings.buildingAddress"),
         field: "buildingAddress.street",
-        sortable: false,
+        sortable: true,
         filter: false,
         resizable: true,
-      },
-      {
-        headerName: t("listings.applicationDeadline"),
-        field: "applicationDueDate",
-        sortable: false,
-        filter: false,
-        resizable: true,
-        valueFormatter: ({ value }) => moment(value).format("MM/DD/YYYY"),
+        flex: 1,
       },
       {
         headerName: t("listings.availableUnits"),

--- a/sites/partners/pages/index.tsx
+++ b/sites/partners/pages/index.tsx
@@ -99,8 +99,8 @@ export default function ListingsList() {
         cellRenderer: "ApplicationsLink",
       },
       {
-        headerName: t("listings.property.buildingAddress"),
-        field: "property.buildingAddress.street",
+        headerName: t("listings.buildingAddress"),
+        field: "buildingAddress.street",
         sortable: false,
         filter: false,
         resizable: true,

--- a/sites/partners/pages/listings/[id]/index.tsx
+++ b/sites/partners/pages/listings/[id]/index.tsx
@@ -32,7 +32,6 @@ import DetailUnitDrawer, {
 import DetailBuildingFeatures from "../../../src/listings/PaperListingDetails/sections/DetailBuildingFeatures"
 import DetailRankingsAndResults from "../../../src/listings/PaperListingDetails/sections/DetailRankingsAndResults"
 import DetailApplicationAddress from "../../../src/listings/PaperListingDetails/sections/DetailApplicationAddress"
-import DetailApplicationDates from "../../../src/listings/PaperListingDetails/sections/DetailApplicationDates"
 import DetailPreferences from "../../../src/listings/PaperListingDetails/sections/DetailPreferences"
 import DetailCommunityType from "../../../src/listings/PaperListingDetails/sections/DetailCommunityType"
 

--- a/sites/partners/pages/listings/[id]/index.tsx
+++ b/sites/partners/pages/listings/[id]/index.tsx
@@ -130,7 +130,6 @@ export default function ApplicationsList() {
                     <DetailRankingsAndResults />
                     <DetailLeasingAgent />
                     <DetailApplicationAddress />
-                    <DetailApplicationDates />
                   </div>
 
                   <div className="md:w-3/12 pl-6">

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -49,7 +49,6 @@ import ListingPhoto from "./sections/ListingPhoto"
 import BuildingFeatures from "./sections/BuildingFeatures"
 import RankingsAndResults from "./sections/RankingsAndResults"
 import ApplicationAddress from "./sections/ApplicationAddress"
-import ApplicationDates from "./sections/ApplicationDates"
 import LotteryResults from "./sections/LotteryResults"
 import Preferences from "./sections/Preferences"
 import CommunityType from "./sections/CommunityType"
@@ -579,11 +578,6 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                           <RankingsAndResults listing={listing} />
                           <LeasingAgent />
                           <ApplicationAddress listing={listing} />
-                          <ApplicationDates
-                            listing={listing}
-                            openHouseEvents={openHouseEvents}
-                            setOpenHouseEvents={setOpenHouseEvents}
-                          />
 
                           <div className="-ml-8 -mt-8 relative" style={{ top: "7rem" }}>
                             <Button


### PR DESCRIPTION
## Issue

- Closes #158

## Description

Removes application information from the partner portal in 3 places:
1. Listings page view
Before
![Screen Shot 2021-08-20 at 12 23 29 PM](https://user-images.githubusercontent.com/4317058/130264835-95ab04b1-3649-448f-beaa-d69af5fbde6e.png)

After
![Screen Shot 2021-08-20 at 12 23 54 PM](https://user-images.githubusercontent.com/4317058/130264864-5444add2-a847-413f-823a-d5ee5a9405ec.png)

2. Single listing view
Removed section:
![Screen Shot 2021-08-20 at 12 22 39 PM](https://user-images.githubusercontent.com/4317058/130264899-b8f1ddbd-6e88-47a7-bdeb-a8722116b2bf.png)

3. Edit listing view
Removed section:
![Screen Shot 2021-08-20 at 12 23 02 PM](https://user-images.githubusercontent.com/4317058/130264917-10e819db-ce70-43b3-a889-69a6c6ec6d1b.png)

Also stops setting applications on Detroit seed listings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

Tested locally.

- [x] Desktop View
- [x] Mobile View - the partner portal looks terrible in Mobile view anyway, but I did make sure the edits worked.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
