### PR TITLE
Disable Google translate since we don't have API keys.

### DIFF
--- a/backend/core/src/translations/translations.service.ts
+++ b/backend/core/src/translations/translations.service.ts
@@ -65,6 +65,12 @@ export class TranslationsService extends AbstractServiceFactory<
   }
 
   public async translateListing(listing: Listing, language: Language) {
+    /**
+     * check for necessary keys before continuing
+     */
+    const { GOOGLE_API_ID, GOOGLE_API_EMAIL, GOOGLE_API_KEY } = process.env
+    if (!GOOGLE_API_ID || !GOOGLE_API_EMAIL || !GOOGLE_API_KEY) return
+
     // Get key-value pairs from listing to be translated
     const translations = this.getTranslations(listing)
 


### PR DESCRIPTION
We don't have a Google Translate API key right now, so we can't use the `translateListing` method in `translationService`. When attempting to get a listing in a different language, the `backend/core` will return a 500. This adds an environment variable such that it will be disabled for us. I will also contribute this upstream.