### PR TITLE
Add Cypress tests for the Eligibility Questionnaire

### DIFF
--- a/sites/public/cypress/integration/eligibility-questionnaire.ts
+++ b/sites/public/cypress/integration/eligibility-questionnaire.ts
@@ -13,13 +13,9 @@ describe("Verifying the eligibility questionnaire flow", () => {
   it("Navigates through the eligibility questionnaire flow", () => {
     cy.visit("/eligibility/welcome")
 
-    // Verify that the page welcomes us :)
-    cy.contains("Welcome")
-
     // Click the "Next" button to go to the "Bedrooms" section.
     cy.contains("Next").click()
     cy.url().should("include", "/eligibility/bedrooms")
-    cy.contains("How many bedrooms do you need?")
 
     // Find and click to indicate both 2BR and 3BR
     cy.get("#twoBdrm").click()
@@ -28,7 +24,6 @@ describe("Verifying the eligibility questionnaire flow", () => {
     // Click "Next" to go to the "Age" section
     cy.contains("Next").click()
     cy.url().should("include", "/eligibility/age")
-    cy.contains("How old are you?")
 
     // Enter "55" for the age input.
     cy.get("input").type("55")
@@ -36,7 +31,6 @@ describe("Verifying the eligibility questionnaire flow", () => {
     // Click "Next" to go to the "Disability" section
     cy.contains("Next").click()
     cy.url().should("include", "/eligibility/disability")
-    cy.contains("Do you have a disability?")
 
     // Click "no" to indicate no disability.
     cy.get("#disabilityNo").click()
@@ -44,7 +38,6 @@ describe("Verifying the eligibility questionnaire flow", () => {
     // Click "Next" to go to the "Income" section
     cy.contains("Next").click()
     cy.url().should("include", "/eligibility/income")
-    cy.contains("What is your total household annual income?")
 
     // Select "$30k to $40k"
     cy.get("select").select("30kTo40k")
@@ -52,7 +45,6 @@ describe("Verifying the eligibility questionnaire flow", () => {
     // Click "Next" to go to the "Section 8" section
     cy.contains("Next").click()
     cy.url().should("include", "/eligibility/section8")
-    cy.contains("Do you have a Section 8 voucher?")
 
     // Click "no" to indicate no Section 8 voucher.
     cy.get("#section8No").click()

--- a/sites/public/cypress/integration/eligibility-questionnaire.ts
+++ b/sites/public/cypress/integration/eligibility-questionnaire.ts
@@ -16,72 +16,54 @@ describe("Verifying the eligibility questionnaire flow", () => {
     // Verify that the page welcomes us :)
     cy.contains("Welcome")
 
-    // Find and click the "Next" button.
+    // Click the "Next" button to go to the "Bedrooms" section.
     cy.contains("Next").click()
-
     cy.url().should("include", "/eligibility/bedrooms")
-
-    // Verify that we're asked next about how many bedrooms
     cy.contains("How many bedrooms do you need?")
 
     // Find and click to indicate both 2BR and 3BR
     cy.get("#twoBdrm").click()
     cy.get("#threeBdrm").click()
 
+    // Click "Next" to go to the "Age" section
     cy.contains("Next").click()
-
     cy.url().should("include", "/eligibility/age")
+    cy.contains("How old are you?")
+
+    // Enter "55" for the age input.
+    cy.get("input").type("55")
+
+    // Click "Next" to go to the "Disability" section
+    cy.contains("Next").click()
+    cy.url().should("include", "/eligibility/disability")
+    cy.contains("Do you have a disability?")
+
+    // Click "no" to indicate no disability.
+    cy.get("#disabilityNo").click()
+
+    // Click "Next" to go to the "Income" section
+    cy.contains("Next").click()
+    cy.url().should("include", "/eligibility/income")
+    cy.contains("What is your total household annual income?")
+
+    // Select "$30k to $40k"
+    cy.get("select").select("30kTo40k")
+
+    // Click "Next" to go to the "Section 8" section
+    cy.contains("Next").click()
+    cy.url().should("include", "/eligibility/section8")
+    cy.contains("Do you have a Section 8 voucher?")
+
+    // Click "no" to indicate no Section 8 voucher.
+    cy.get("#section8No").click()
+
+    // Click "Done"
+    cy.contains("Done").click()
+
+    // TODO: once the "Done" button is implemented, verify that it takes the user to the correct
+    // view.
   })
 
-  /*
-  it("Loads the listings page directly", () => {
-    cy.visit("/listings")
-
-    // Check that the listings page banner text is present on the page
-    cy.contains("Rent affordable housing")
-  })
-
-  it("Loads the listings page directly", () => {
-    cy.visit("/listings")
-
-    // Check that the listings page banner text is present on the page
-    cy.contains("Rent affordable housing")
-  })
-
-  it("Loads a non-listing-related page directly", () => {
-    cy.visit("/disclaimer")
-
-    // Check that the Disclaimer page banner text is present on the page
-    cy.contains("Endorsement Disclaimers")
-  })
-
-  it("Can navigate to all page types after initial site load", () => {
-    cy.visit("/")
-
-    // Click on the Disclaimer page link in the footer
-    cy.get("footer a").contains("Disclaimer").click()
-
-    // Should be on the disclaimer page
-    cy.location("pathname").should("equal", "/disclaimer")
-    cy.contains("Endorsement Disclaimers")
-
-    // Click on the listings page link in the header nav
-    cy.get(".navbar").contains("Listings").click()
-
-    // Should be on the listings page
-    cy.location("pathname").should("equal", "/listings")
-    cy.contains("Rent affordable housing")
-
-    // Click on the navbar logo to go to the homepage
-    cy.get(".navbar")
-      .first()
-      .within(() => {
-        cy.get(".logo").click()
-      })
-
-    // Check that the homepage banner text is present on the page
-    cy.url().should("eq", `${Cypress.config("baseUrl")}/`)
-    cy.contains("Apply for affordable housing")
-  })
-  */
+  // TODO: consider adding tests for incorrect inputs in the Eligibility Questionnaire.
+  // Example: A user enters an age of 999 and clicks "Next".
 })

--- a/sites/public/cypress/integration/eligibility-questionnaire.ts
+++ b/sites/public/cypress/integration/eligibility-questionnaire.ts
@@ -1,0 +1,87 @@
+describe("Verifying the eligibility questionnaire flow", () => {
+  it("Clicks the button on the homepage to launch the eligibility questionnaire", () => {
+    cy.visit("/")
+
+    // Find and click the button that says "Check My Eligibility"
+    const checkEligibilityButton = cy.contains("Check My Eligibility")
+
+    // Click the eligibility button and verify it takes us to the questionnaire welcome page
+    checkEligibilityButton.click()
+    cy.url().should("include", "/eligibility/welcome")
+  })
+
+  it("Navigates through the eligibility questionnaire flow", () => {
+    cy.visit("/eligibility/welcome")
+
+    // Verify that the page welcomes us :)
+    cy.contains("Welcome")
+
+    // Find and click the "Next" button.
+    cy.contains("Next").click()
+
+    cy.url().should("include", "/eligibility/bedrooms")
+
+    // Verify that we're asked next about how many bedrooms
+    cy.contains("How many bedrooms do you need?")
+
+    // Find and click to indicate both 2BR and 3BR
+    cy.get("#twoBdrm").click()
+    cy.get("#threeBdrm").click()
+
+    cy.contains("Next").click()
+
+    cy.url().should("include", "/eligibility/age")
+  })
+
+  /*
+  it("Loads the listings page directly", () => {
+    cy.visit("/listings")
+
+    // Check that the listings page banner text is present on the page
+    cy.contains("Rent affordable housing")
+  })
+
+  it("Loads the listings page directly", () => {
+    cy.visit("/listings")
+
+    // Check that the listings page banner text is present on the page
+    cy.contains("Rent affordable housing")
+  })
+
+  it("Loads a non-listing-related page directly", () => {
+    cy.visit("/disclaimer")
+
+    // Check that the Disclaimer page banner text is present on the page
+    cy.contains("Endorsement Disclaimers")
+  })
+
+  it("Can navigate to all page types after initial site load", () => {
+    cy.visit("/")
+
+    // Click on the Disclaimer page link in the footer
+    cy.get("footer a").contains("Disclaimer").click()
+
+    // Should be on the disclaimer page
+    cy.location("pathname").should("equal", "/disclaimer")
+    cy.contains("Endorsement Disclaimers")
+
+    // Click on the listings page link in the header nav
+    cy.get(".navbar").contains("Listings").click()
+
+    // Should be on the listings page
+    cy.location("pathname").should("equal", "/listings")
+    cy.contains("Rent affordable housing")
+
+    // Click on the navbar logo to go to the homepage
+    cy.get(".navbar")
+      .first()
+      .within(() => {
+        cy.get(".logo").click()
+      })
+
+    // Check that the homepage banner text is present on the page
+    cy.url().should("eq", `${Cypress.config("baseUrl")}/`)
+    cy.contains("Apply for affordable housing")
+  })
+  */
+})


### PR DESCRIPTION
## Issue

- Addresses #219 

## Description

This change adds two Cypress tests for the Eligibility Questionnaire:
- The first verifies that users can access the questionnaire by clicking "Check My Eligibility" on the homepage
- The second verifies that users can navigate through the entire questionnaire flow

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script
- [X] Adds tests

## How Can This Be Tested/Reviewed?

```
$ cd sites/public
$ yarn test:headless
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes