### PR TITLE
Initial changes to accept empty strings

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -24,7 +24,11 @@ import { useRouter } from "next/router"
 import { useListingsData } from "../lib/hooks"
 import { ListingFilterKeys, ListingFilterParams } from "@bloom-housing/backend-core/types"
 
-const isValidZipCode = (value: string) => {
+const isValidZipCodeOrEmpty = (value: string) => {
+  // Empty strings or whitespace are valid and will reset the filter.
+  if (!value.trim()) {
+    return true
+  }
   let returnValue = true
   value.split(",").forEach((element) => {
     if (!/^[0-9]{5}$/.test(element.trim())) {
@@ -132,7 +136,7 @@ const ListingsPage = () => {
               controlClassName="control"
               placeholder={t("listingFilters.zipCodeDescription")}
               validation={{
-                validate: (value) => isValidZipCode(value),
+                validate: (value) => isValidZipCodeOrEmpty(value),
               }}
               error={errors.zipCodeField}
               errorMessage={t("errors.multipleZipCodeError")}


### PR DESCRIPTION
## Issue

- Addresses #429

## Description

Allow the empty string in the zipcode field, which will clear the zipcode filter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

Start the frontend, filter on zipcodes, and then remove the text from the zipcode field and apply.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
