### PR TITLE
Add Region field to listing details

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -83,6 +83,7 @@ export const ListingView = (props: ListingProps) => {
   const shouldShowFeaturesDetail = () => {
     return (
       listing.neighborhood ||
+      listing.region ||
       listing.yearBuilt ||
       listing.smokingPolicy ||
       listing.petPolicy ||

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -208,6 +208,9 @@ export const ListingView = (props: ListingProps) => {
                 {listing.neighborhood && (
                   <Description term={t("t.neighborhood")} description={listing.neighborhood} />
                 )}
+                {listing.region && (
+                  <Description term={t("t.region")} description={listing.region} />
+                )}
                 {listing.yearBuilt && (
                   <Description term={t("t.built")} description={listing.yearBuilt} />
                 )}

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -1161,6 +1161,7 @@
         "range": "٪ {from} إلى٪ {to}",
         "readLess": "أقرأ أقل",
         "readMore": "قراءة المزيد",
+        "region":"منطقة",
         "relationship": "صلة",
         "otherRelationShip": "علاقة أخرى",
         "rent": "إيجار",

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -1161,6 +1161,7 @@
         "range": "%{থেকে} থেকে %{থেকে}",
         "readLess": "কম পড়ুন",
         "readMore": "আরো পড়ুন",
+        "region":"অঞ্চল",
         "relationship": "সম্পর্ক",
         "otherRelationShip": "অন্যান্য সম্পর্ক",
         "rent": "ভাড়া",

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1161,6 +1161,7 @@
         "range": "% {from} a% {to}",
         "readLess": "Leer menos",
         "readMore": "Lee mas",
+        "region":"Región",
         "relationship": "Relación",
         "otherRelationShip": "Otra relación",
         "rent": "Alquiler",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1216,6 +1216,7 @@
     "range": "%{from} to %{to}",
     "readLess": "read less",
     "readMore": "read more",
+    "region":"Region",
     "relationship": "Relationship",
     "otherRelationShip": "Other Relationship",
     "rent": "Rent",


### PR DESCRIPTION
## Issue

- Closes #350

## Description
Adds the Region field to the Features details on a listing page.  Only appears when the data is present.
![image](https://user-images.githubusercontent.com/82653098/130663768-f9eaa7a9-208d-4738-8581-66295bb109c4.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Load any Region data for a listing and view the Features box.

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
