### PR TITLE
Remove unit table breakdown by AMI percentage

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -49,22 +49,9 @@ export const ListingView = (props: ListingProps) => {
     totalCount: t("t.totalCount"),
   }
 
-  const amiValues = listing?.unitsSummarized?.amiPercentages
-    ? listing.unitsSummarized.amiPercentages
-        .map((percent) => {
-          const percentInt = parseInt(percent, 10)
-          return percentInt
-        })
-        .sort(function (a, b) {
-          return a - b
-        })
-    : []
-
-  let groupedUnits: GroupedTableGroup[] = null
-
-  if (amiValues.length == 1) {
-    groupedUnits = getSummariesTable(listing.unitsSummarized.byUnitTypeAndRent)
-  } // else condition is handled inline below
+  const groupedUnits: GroupedTableGroup[] = getSummariesTable(
+    listing.unitsSummarized.byUnitTypeAndRent
+  )
 
   let openHouseEvents: ListingEvent[] | null = null
   if (Array.isArray(listing.events)) {
@@ -134,32 +121,12 @@ export const ListingView = (props: ListingProps) => {
             })}
           </Message>
         )}
-        {amiValues.length > 1 &&
-          amiValues.map((percent) => {
-            const byAMI = listing.unitsSummarized.byAMI.find((item) => {
-              return parseInt(item.percent, 10) == percent
-            })
 
-            groupedUnits = byAMI ? getSummariesTable(byAMI.byUnitType) : []
-
-            return (
-              <>
-                <h2 className="mt-4 mb-2">{t("listings.percentAMIUnit", { percent: percent })}</h2>
-                <GroupedTable
-                  headers={unitSummariesHeaders}
-                  data={groupedUnits}
-                  responsiveCollapse={true}
-                />
-              </>
-            )
-          })}
-        {amiValues.length == 1 && (
-          <GroupedTable
-            headers={unitSummariesHeaders}
-            data={groupedUnits}
-            responsiveCollapse={true}
-          />
-        )}
+        <GroupedTable
+          headers={unitSummariesHeaders}
+          data={groupedUnits}
+          responsiveCollapse={true}
+        />
       </div>
       <div className="w-full md:w-2/3 md:mt-3 md:hidden md:mx-3 border-gray-400 border-b">
         <ListingUpdated listingUpdated={listing.updatedAt} />


### PR DESCRIPTION
## Issue

- Addresses #347 
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This change collapses the per-AMI unit tables into a single unit table, in the individual listing view.

Before:

![image](https://user-images.githubusercontent.com/8754454/130691262-cf605c2d-fcc3-48ca-9c9e-df4ad14bb715.png)

After:

![image](https://user-images.githubusercontent.com/8754454/130691315-0caaa07a-b620-42d8-9304-f137f1775a9f.png)

This change also fixes a bug: previously, the unit table didn't show up at all for the Detroit data. With this change, we always show a single unit table in the individual-listing view.

Forward-looking note: in the future, we may decide that we want to display either AMI percentages or income eligibility requirements (derived from AMI percentages) or something else. At that point, we could either revert this change (so that we go back to "individual tables per AMI percentage") or we could just add a new column to the table.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Start the app and look at the individual listing view for listings with units at different AMI percentages (e.g. "TEST: DEFAULT, MULTIPLE AMI AND PERCENTAGES") and for listings with units all at the same AMI percentage (e.g. "TEST: DEFAULT, RESERVED").

- [X] Desktop View
- [X] Mobile View

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
