### PR TITLE
Add override translations

### DIFF
--- a/sites/public/.jest/setup-tests.js
+++ b/sites/public/.jest/setup-tests.js
@@ -1,4 +1,6 @@
 import { addTranslation } from "../../../ui-components/src/helpers/translator"
 import general from "../../../ui-components/src/locales/general.json"
+import general_overrides from "../page_content/locale_overrides/general.json"
 
 addTranslation(general)
+addTranslation(general_overrides)


### PR DESCRIPTION
## Issue

- Addresses #219 
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Before this change, running `cd sites/public && yarn test:unit-tests` reported that a bunch of translations were missing (because they were in our translation overrides file). This change adds translations for the overrides file, and the warnings are gone.
