### PR TITLE
499/Remove subtitle from front page

### DIFF
--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -53,9 +53,7 @@ export default function Home() {
         buttonTitle={t("welcome.seeRentalListings")}
         buttonLink="/listings?page=1"
         backgroundImage={"/images/hero.png"}
-      >
-        {t("welcome.subTitle")}
-      </Hero>
+      />
       <div className="homepage-extra">
         <MarkdownSection fullwidth={true}>
           <>


### PR DESCRIPTION
## Issue

- Closes #499

## Description

Removes the subtitle entirely from the public front page, it doesn't add any new information.

## How Can This Be Tested/Reviewed?

View the front page:
![Screen Shot 2021-08-31 at 4 06 35 PM](https://user-images.githubusercontent.com/4317058/131568987-0789489f-7a9d-4150-9d47-453b93ce5e19.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
