### PR TITLE
Fix undefined unitsSummarized property.

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -51,7 +51,7 @@ export const ListingView = (props: ListingProps) => {
   }
 
   const groupedUnits: GroupedTableGroup[] = getSummariesTableFromUnitSummary(
-    listing.unitsSummarized.byUnitTypeAndRent
+    listing.unitsSummarized?.byUnitTypeAndRent
   )
 
   let openHouseEvents: ListingEvent[] | null = null


### PR DESCRIPTION
The details page would fail to render if the listing did not have a unitsSummarized. This passes it optionally. Fixes the currently broken deployment.
