### PR TITLE
Show Accessibility details or default message

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -205,9 +205,10 @@ export const ListingView = (props: ListingProps) => {
                     description={listing.servicesOffered}
                   />
                 )}
-                {listing.accessibility && (
-                  <Description term={t("t.accessibility")} description={listing.accessibility} />
-                )}
+                <Description
+                  term={t("t.accessibility")}
+                  description={listing.accessibility || t("t.contactPropertyManagement")}
+                />
                 <Description
                   term={t("t.unitFeatures")}
                   description={

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -1156,7 +1156,7 @@
         "call": "مكالمة",
         "cancel": "يلغي",
         "confirm": "يتأكد",
-        "contactPropertyManagement":"اتصل بإدارة الممتلكات",
+        "contactPropertyManagement": "اتصل بإدارة الممتلكات",
         "chooseFromFolder": "اختر من المجلد",
         "custom": "مخصص",
         "day": "يوم",

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -1156,6 +1156,7 @@
         "call": "مكالمة",
         "cancel": "يلغي",
         "confirm": "يتأكد",
+        "contactPropertyManagement":"اتصل بإدارة الممتلكات",
         "chooseFromFolder": "اختر من المجلد",
         "custom": "مخصص",
         "day": "يوم",

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -1156,7 +1156,7 @@
         "call": "ডাক",
         "cancel": "বাতিল করুন",
         "confirm": "নিশ্চিত করুন",
-        "contactPropertyManagement":"সম্পত্তি পরিচালনার সাথে যোগাযোগ করুন",
+        "contactPropertyManagement": "সম্পত্তি পরিচালনার সাথে যোগাযোগ করুন",
         "chooseFromFolder": "ফোল্ডার থেকে বেছে নিন",
         "custom": "কাস্টম",
         "day": "দিন",

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -1156,6 +1156,7 @@
         "call": "ডাক",
         "cancel": "বাতিল করুন",
         "confirm": "নিশ্চিত করুন",
+        "contactPropertyManagement":"সম্পত্তি পরিচালনার সাথে যোগাযোগ করুন",
         "chooseFromFolder": "ফোল্ডার থেকে বেছে নিন",
         "custom": "কাস্টম",
         "day": "দিন",

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1156,6 +1156,7 @@
         "call": "Llamada",
         "cancel": "Cancelar",
         "confirm": "Confirmar",
+        "contactPropertyManagement":"Contactar con la administración de la propiedad",
         "chooseFromFolder": "Elija de la carpeta",
         "custom": "Personalizado",
         "day": "Día",

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1156,7 +1156,7 @@
         "call": "Llamada",
         "cancel": "Cancelar",
         "confirm": "Confirmar",
-        "contactPropertyManagement":"Contactar con la administración de la propiedad",
+        "contactPropertyManagement": "Contactar con la administración de la propiedad",
         "chooseFromFolder": "Elija de la carpeta",
         "custom": "Personalizado",
         "day": "Día",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1161,7 +1161,7 @@
     "call": "Call",
     "cancel": "Cancel",
     "confirm": "Confirm",
-    "contactPropertyManagement":"Contact property management",
+    "contactPropertyManagement": "Contact property management",
     "chooseFromFolder": "Choose from folder",
     "custom": "Custom",
     "day": "Day",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1161,6 +1161,7 @@
     "call": "Call",
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "contactPropertyManagement":"Contact property management",
     "chooseFromFolder": "Choose from folder",
     "custom": "Custom",
     "day": "Day",


### PR DESCRIPTION
## Issue
- Addresses #231 

## Description
On a listing page view, this change shows the Accessibility section under Features.  If there is no accessibility information available for the listing, it will display a default "Contact property manager" message.

![image](https://user-images.githubusercontent.com/82653098/131738957-9ee89b83-78ea-4a49-9051-9aa2a29562a3.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

View a listing page and look under the Features section for Accessibility. 

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
