### PR TITLE
Remove the "Total Count" column from the units summary table in `ListingView`

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -47,7 +47,6 @@ export const ListingView = (props: ListingProps) => {
     minimumIncome: t("t.minimumIncome"),
     rent: t("t.rent"),
     availability: t("t.availability"),
-    totalCount: t("t.totalCount"),
   }
 
   const groupedUnits: GroupedTableGroup[] = getSummariesTableFromUnitSummary(

--- a/ui-components/src/helpers/tableSummaries.tsx
+++ b/ui-components/src/helpers/tableSummaries.tsx
@@ -5,7 +5,6 @@ import { GroupedTableGroup } from "../tables/GroupedTable"
 
 export const getSummaryRow = (
   totalAvailable: number,
-  totalCount: number,
   minIncomeRangeMin?: string,
   minIncomeRangeMax?: string,
   rentRangeMin?: string,
@@ -90,11 +89,6 @@ export const getSummaryRow = (
         )}
       </>
     ),
-    totalCount: (
-      <>
-        <strong>{totalCount}</strong> {totalCount == 1 ? t("t.unit") : t("t.units")}
-      </>
-    ),
   }
 }
 
@@ -105,7 +99,6 @@ export const getSummariesTableFromUnitSummary = (summaries: UnitSummary[]) => {
     const unitSummaries = summaries.map((unitSummary) => {
       return getSummaryRow(
         unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
-        unitSummary.totalCount ? unitSummary.totalCount : 0,
         unitSummary.minIncomeRange.min,
         unitSummary.minIncomeRange.max,
         unitSummary.rentRange.min,
@@ -135,7 +128,6 @@ export const getSummariesTableFromUnitsSummary = (summaries: UnitsSummary[]) => 
     const unitSummaries = summaries.map((unitSummary) => {
       return getSummaryRow(
         unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
-        unitSummary.totalCount ? unitSummary.totalCount : 0,
         unitSummary.minimumIncomeMin,
         unitSummary.minimumIncomeMax,
         unitSummary.monthlyRentMin?.toString(),


### PR DESCRIPTION
## Issue

- Addresses #347

## Description

This change removes the "total count" column from the unit summary table in the individual-listing view. It also removes everything related to `totalCount` in the shared `getSummariesTableFromUnitsSummary` since the only other component that uses that function (`ListingsList`) already doesn't display "total count".

Note: we've gone back and forth on whether or not to include "total count". I'm sending this PR based on https://github.com/CityOfDetroit/bloom/pull/460#issuecomment-905625330.

Before:

![image](https://user-images.githubusercontent.com/8754454/131743984-ed7afad7-d789-46c7-a162-d9210b1f44d0.png)

After:

![image](https://user-images.githubusercontent.com/8754454/131744012-080d47db-4f6f-465f-a0be-aa6f37912584.png)

## How Can This Be Tested/Reviewed?

Run the app and navigate to any listing's individual-listing view.

- [X] Desktop View
- [X] Mobile View

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
