### PR TITLE
Small changes to make the `sites/partners` Cypress tests work

### DIFF
--- a/sites/partners/cypress.json
+++ b/sites/partners/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "http://localhost:3001",
   "defaultCommandTimeout": 10000,
   "projectId": "bloom-partners-reference"
 }

--- a/sites/partners/cypress/fixtures/user.json
+++ b/sites/partners/cypress/fixtures/user.json
@@ -1,7 +1,9 @@
 {
-  "email": "test@example.com",
-  "password": "abcdef",
+  "email": "cypress@example.com",
+  "emailConfirmation": "cypress@example.com",
+  "password": "abcdef123?!",
+  "passwordConfirmation": "abcdef123?!",
   "firstName": "Test",
   "lastName": "User",
-  "dob": "1980-01-01"
+  "dob": "1980-01-01",
 }

--- a/sites/partners/cypress/fixtures/user.json
+++ b/sites/partners/cypress/fixtures/user.json
@@ -1,9 +1,4 @@
 {
-  "email": "cypress@example.com",
-  "emailConfirmation": "cypress@example.com",
-  "password": "abcdef123?!",
-  "passwordConfirmation": "abcdef123?!",
-  "firstName": "Test",
-  "lastName": "User",
-  "dob": "1980-01-01",
+  "email": "admin@example.com",
+  "password": "abcdef"
 }

--- a/sites/partners/cypress/integration/navigation.ts
+++ b/sites/partners/cypress/integration/navigation.ts
@@ -1,10 +1,6 @@
 /// <reference types="cypress" />
 
 describe("Navigating around the site", () => {
-  before(() => {
-    cy.fixture("user").then((user) => cy.createUser(user))
-  })
-
   describe("with a logged out user", () => {
     beforeEach(() => {
       cy.logout()
@@ -16,26 +12,29 @@ describe("Navigating around the site", () => {
       cy.contains("Sign In")
     })
 
+    // Note: this test relies on the user referenced by the user.json fixture already existing (as an admin user) in the database.
     it("Signs in", () => {
       cy.visit("/")
       cy.fixture("user").then((user) => {
         cy.get("input#email").type(user.email)
         cy.get("input#password").type(user.password)
         cy.get(".button.is-primary").contains("Sign In").click()
-        cy.contains("This will be the home page")
+        cy.contains("Listings")
       })
     })
   })
 
   describe("with a logged in user", () => {
+    // Note: this test relies on the user referenced by the user.json fixture already existing (as an admin user) in the database.
     beforeEach(() => {
       cy.fixture("user").then(({ email, password }) => cy.login(email, password))
     })
 
-    it("Visits the applications page using the home page link", () => {
+    it("Visits the listings page using the home page link and clicks to add a new listing", () => {
       cy.visit("/")
-      cy.contains("View Submitted Applications").click()
-      cy.contains("List of Applications will go here.")
+      cy.contains("Listings")
+      cy.contains("Add Listing").click()
+      cy.contains("New Listing")
     })
   })
 })

--- a/sites/partners/cypress/integration/navigation.ts
+++ b/sites/partners/cypress/integration/navigation.ts
@@ -21,7 +21,7 @@ describe("Navigating around the site", () => {
       cy.fixture("user").then((user) => {
         cy.get("input#email").type(user.email)
         cy.get("input#password").type(user.password)
-        cy.get(".button.is-filled").contains("Sign In").click()
+        cy.get(".button.is-primary").contains("Sign In").click()
         cy.contains("This will be the home page")
       })
     })

--- a/sites/partners/cypress/support/index.ts
+++ b/sites/partners/cypress/support/index.ts
@@ -16,16 +16,6 @@
 // Import commands.ts using ES2015 syntax:
 import { ACCESS_TOKEN_LOCAL_STORAGE_KEY } from "@bloom-housing/ui-components"
 
-// TODO: Replace this with a DTO to avoid duplication
-type UserFields = {
-  email: string
-  firstName: string
-  middleName?: string
-  lastName: string
-  dob: Date
-  password: string
-}
-
 // If TypeScript considers this file a module (as opposed to a script), then we need to define this as a global for
 // it to register. See:
 // https://github.com/cypress-io/add-cypress-custom-command-in-typescript/issues/2#issuecomment-389870033
@@ -44,11 +34,6 @@ declare global {
        * Logout from the app (clears session storage's saved version of the key.)
        */
       logout(): Chainable
-
-      /**
-       * Create a new user with the specified options.
-       */
-      createUser(user: UserFields, options?: { apiBase: string }): Chainable
     }
   }
 }
@@ -73,19 +58,4 @@ Cypress.Commands.add(
 
 Cypress.Commands.add("logout", () =>
   cy.window().then((window) => window.sessionStorage.removeItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY))
-)
-
-Cypress.Commands.add(
-  "createUser",
-  (user: UserFields, { apiBase = "http://localhost:3100" } = {}) => {
-    console.error("\n\n\n\nI AM HEREEEEEEEEEE\n\n\n\n")
-    return cy
-      .request({
-        url: `${apiBase}/user?noWelcomeEmail=true`,
-        method: "POST",
-        body: user,
-      })
-      .its("body")
-      .then(({ accessToken }) => accessToken)
-  }
 )

--- a/sites/partners/cypress/support/index.ts
+++ b/sites/partners/cypress/support/index.ts
@@ -75,13 +75,17 @@ Cypress.Commands.add("logout", () =>
   cy.window().then((window) => window.sessionStorage.removeItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY))
 )
 
-Cypress.Commands.add("createUser", (user: UserFields, { apiBase = "http://localhost:3100" } = {}) =>
-  cy
-    .request({
-      url: `${apiBase}/user`,
-      method: "POST",
-      body: user,
-    })
-    .its("body")
-    .then(({ accessToken }) => accessToken)
+Cypress.Commands.add(
+  "createUser",
+  (user: UserFields, { apiBase = "http://localhost:3100" } = {}) => {
+    console.error("\n\n\n\nI AM HEREEEEEEEEEE\n\n\n\n")
+    return cy
+      .request({
+        url: `${apiBase}/user?noWelcomeEmail=true`,
+        method: "POST",
+        body: user,
+      })
+      .its("body")
+      .then(({ accessToken }) => accessToken)
+  }
 )

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -8,13 +8,15 @@
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect=9231' next -p ${NEXTJS_PORT:-3001}",
     "build": "next build",
-    "test": "concurrently \"yarn dev\" \"cypress open\"",
-    "test:headless": "concurrently \"yarn dev\" \"cypress run\"",
+    "cypress:open": "wait-on \"http-get://localhost:${PORT:-3100}/docs\" \"http-get://localhost:${PORT:-3001}\" && cypress open",
+    "cypress:run": "wait-on \"http-get://localhost:${PORT:-3100}/docs\" \"http-get://localhost:${PORT:-3001}\" && cypress run",
+    "test": "concurrently \"yarn dev:all\" \"yarn cypress:open\"",
+    "test:headless": "concurrently \"yarn dev:all\" \"yarn cypress:run\"",
     "export": "next export",
     "start": "next start",
-    "dev:listings": "cd ../../backend/core && yarn dev",
-    "dev:server-wait": "wait-on \"http-get://localhost:${PORT:-3100}/listings\" && yarn dev",
-    "dev:all": "concurrently \"yarn dev:listings\" \"yarn dev:server-wait\""
+    "dev:backend": "cd ../../backend/core && yarn db:reseed && yarn dev",
+    "dev:server-wait": "wait-on \"http-get://localhost:${PORT:-3100}/docs\" && yarn dev",
+    "dev:all": "concurrently \"yarn dev:backend\" \"yarn dev:server-wait\""
   },
   "dependencies": {
     "@bloom-housing/ui-components": "^1.0.5",


### PR DESCRIPTION
## Issue

- Addresses #521

## Description

This change does a few things:
- Stop trying to create a new user for the `sites/partners/cypress/integration/navigation.ts` test suite. Instead, use a seeded admin user that already exists in the database. (The test requires a partner/admin user, and there's no way to create one through the backend currently.)
- Update the yarn commands that run Cypress tests to start up both the partner portal and the backend (after a db:reseed). Also small cosmetic changes to the yarn commands.
- Small changes to the `navigation.ts` test itself to bring it up-to-date with the current state of the partner portal.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd sites/partners && yarn test:headless`

(Note: this does take quite a while; i.e. O(minutes))

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
