### PR TITLE
Stop casting integer field to text in query

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -856,11 +856,8 @@ export class ListingsRetrieveQueryParams {
   view?: string
 }
 
-const FilterKeysList = { ...ListingFilterKeys, ...AvailabilityFilterEnum }
-type FilterKeysList = typeof FilterKeysList
-
 // Using a record lets us enforce that all types are handled in addFilter
-export const filterTypeToFieldMap: Record<keyof typeof FilterKeysList, string> = {
+export const filterTypeToFieldMap: Record<keyof typeof ListingFilterKeys, string> = {
   status: "listings.status",
   name: "listings.name",
   neighborhood: "property.neighborhood",
@@ -870,7 +867,4 @@ export const filterTypeToFieldMap: Record<keyof typeof FilterKeysList, string> =
   // Fields for the availability are determined based on the value of the filter, not the
   // key. Keep this bogus value to prevent the filter from being rejected.
   availability: "",
-  hasAvailability: "unitsSummary.total_available",
-  noAvailability: "unitsSummary.total_available",
-  waitlist: "listings.is_waitlist_open",
 }

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -200,7 +200,7 @@ describe("ListingsService", () => {
       }
 
       await expect(service.list(queryParams)).rejects.toThrow(
-        new HttpException("Filter Not Implemented", HttpStatus.NOT_IMPLEMENTED)
+        new HttpException('Filter "otherField" Not Implemented', HttpStatus.NOT_IMPLEMENTED)
       )
     })
 

--- a/backend/core/src/shared/filter/custom_filters.ts
+++ b/backend/core/src/shared/filter/custom_filters.ts
@@ -4,7 +4,6 @@ import {
   ListingFilterKeys,
 } from "../../listings/types/listing-filter-keys-enum"
 import { filterTypeToFieldMap } from "../../listings/dto/listing.dto"
-import { Compare } from "../dto/filter.dto"
 
 export function addSeniorHousingQuery(qb: WhereExpression, filterValue: string) {
   const whereParameterName = ListingFilterKeys.seniorHousing
@@ -26,29 +25,23 @@ export function addSeniorHousingQuery(qb: WhereExpression, filterValue: string) 
   }
 }
 
-function addAvailabilityParams(
-  qb: WhereExpression,
-  filterType: AvailabilityFilterEnum,
-  comparison: string,
-  filterValue: any
-) {
-  const hasAvailabilityColumnName = `LOWER(CAST(${filterTypeToFieldMap[filterType]} as text))`
-  const whereParameterName = filterType
-  qb.andWhere(`${hasAvailabilityColumnName} ${comparison} LOWER(:${whereParameterName})`, {
-    [whereParameterName]: filterValue,
-  })
-}
-
 export function addAvailabilityQuery(qb: WhereExpression, filterValue: AvailabilityFilterEnum) {
+  const whereParameterName = "availability"
   switch (filterValue) {
     case AvailabilityFilterEnum.hasAvailability:
-      addAvailabilityParams(qb, filterValue, Compare[">="], 1)
+      qb.andWhere(`unitsSummary.total_available >= :${whereParameterName}`, {
+        [whereParameterName]: 1,
+      })
       return
     case AvailabilityFilterEnum.noAvailability:
-      addAvailabilityParams(qb, filterValue, Compare["="], 0)
+      qb.andWhere(`unitsSummary.total_available = :${whereParameterName}`, {
+        [whereParameterName]: 0,
+      })
       return
     case AvailabilityFilterEnum.waitlist:
-      addAvailabilityParams(qb, filterValue, Compare["="], true)
+      qb.andWhere(`listings.is_waitlist_open = :${whereParameterName}`, {
+        [whereParameterName]: true,
+      })
       return
     default:
       return

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -61,7 +61,10 @@ export function addFilters<FilterParams, FilterFieldMap>(
 
         // Throw if this is not a supported filter type
         if (!(filterType in filterTypeToFieldMap)) {
-          throw new HttpException("Filter Not Implemented", HttpStatus.NOT_IMPLEMENTED)
+          throw new HttpException(
+            `Filter "${filterType}" Not Implemented`,
+            HttpStatus.NOT_IMPLEMENTED
+          )
         }
 
         values.forEach((filterValue: string, i: number) => {
@@ -93,13 +96,17 @@ export function addFilters<FilterParams, FilterFieldMap>(
               break
             case Compare["<>"]:
             case Compare["="]:
-            case Compare[">="]:
               qb.andWhere(
                 `LOWER(CAST(${filterField} as text)) ${comparison} LOWER(:${whereParameterName})`,
                 {
                   [whereParameterName]: filterValue,
                 }
               )
+              break
+            case Compare[">="]:
+              qb.andWhere(`${filterField} ${comparison} :${whereParameterName}`, {
+                [whereParameterName]: filterValue,
+              })
               break
             case Compare.NA:
               // If we're here, it's because we expected this filter to be handled by a custom filter handler


### PR DESCRIPTION
## Issue #524 

- Closes #524 
- Addresses #524 

## Description
We were casting integer fields to text before using a `>=` comparison, which does a lexicographic comparison instead of a numeric one. This would cause problems when comparing values like "30" and "1400" as text. The "30" would be "larger" because 3 comes after 1.

- Removes cast for the availability filter and when the comparison is `>=`.
- Moves the database fields for the availability filter uses out of the map, for simplicity.
- I did not add tests for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] URL like `http://localhost:3100/listings?view=full&filter[$comparison]=NA&filter[availability]=waitlist`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
