### PR TITLE
Migrate unitSummary amiPercentage column to int

### DIFF
--- a/backend/core/src/migration/1630699221778-change-ami-percentage-to-integer.ts
+++ b/backend/core/src/migration/1630699221778-change-ami-percentage-to-integer.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class changeAmiPercentageToInteger1630699221778 implements MigrationInterface {
+    name = 'changeAmiPercentageToInteger1630699221778'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE integer USING ami_percentage::integer`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE text USING ami_percentage::text`)
+    }
+
+}

--- a/backend/core/src/migration/1630699221778-change-ami-percentage-to-integer.ts
+++ b/backend/core/src/migration/1630699221778-change-ami-percentage-to-integer.ts
@@ -1,14 +1,17 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class changeAmiPercentageToInteger1630699221778 implements MigrationInterface {
-    name = 'changeAmiPercentageToInteger1630699221778'
+  name = "changeAmiPercentageToInteger1630699221778"
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE integer USING ami_percentage::integer`)
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE integer USING ami_percentage::integer`
+    )
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE text USING ami_percentage::text`)
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "units_summary" ALTER COLUMN "ami_percentage" TYPE text USING ami_percentage::text`
+    )
+  }
 }

--- a/backend/core/src/units-summary/entities/units-summary.entity.ts
+++ b/backend/core/src/units-summary/entities/units-summary.entity.ts
@@ -49,11 +49,11 @@ class UnitsSummary {
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   monthlyRentAsPercentOfIncome?: string | null
 
-  @Column({ nullable: true, type: "text" })
+  @Column({ nullable: true, type: "integer" })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })
-  amiPercentage?: string | null
+  amiPercentage?: number | null
 
   @Column({ nullable: true, type: "text" })
   @Expose()

--- a/backend/core/src/units-summary/entities/units-summary.entity.ts
+++ b/backend/core/src/units-summary/entities/units-summary.entity.ts
@@ -52,7 +52,7 @@ class UnitsSummary {
   @Column({ nullable: true, type: "integer" })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
   amiPercentage?: number | null
 
   @Column({ nullable: true, type: "text" })

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4132,7 +4132,7 @@ export interface UnitsSummary {
   monthlyRentAsPercentOfIncome?: string
 
   /**  */
-  amiPercentage?: string
+  amiPercentage?: number
 
   /**  */
   minimumIncomeMin?: string
@@ -4587,7 +4587,7 @@ export interface UnitsSummaryCreate {
   monthlyRentAsPercentOfIncome?: string
 
   /**  */
-  amiPercentage?: string
+  amiPercentage?: number
 
   /**  */
   minimumIncomeMin?: string
@@ -5078,7 +5078,7 @@ export interface UnitsSummaryUpdate {
   monthlyRentAsPercentOfIncome?: string
 
   /**  */
-  amiPercentage?: string
+  amiPercentage?: number
 
   /**  */
   minimumIncomeMin?: string


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #478

- [x] This change addresses only certain aspects of the issue

## Description
Migrate the amiPercentage column on the unit summary table to an integer, so we can filter based on it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Can This Be Tested/Reviewed?

Ran the tests and built the site

- [ ] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
