### PR TITLE
Migrate filters to use units summary

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -884,7 +884,7 @@ export const filterTypeToFieldMap: Record<keyof typeof ListingFilterKeys, string
   status: "listings.status",
   name: "listings.name",
   neighborhood: "property.neighborhood",
-  bedrooms: "unitTypeRef.num_bedrooms",
+  bedrooms: "summaryUnitType.num_bedrooms",
   zipcode: "buildingAddress.zipCode",
   seniorHousing: "reservedCommunityType.name",
   // Fields for the availability are determined based on the value of the filter, not the

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -34,15 +34,14 @@ export class ListingsService {
 
   public async list(params: ListingsQueryParams): Promise<Pagination<Listing>> {
     // Inner query to get the sorted listing ids of the listings to display
-    // TODO(avaleske): Only join the tables we need for the filters that are applied
+    // TODO(avaleske): Only join the tables we need for the filters that are applied.
     const innerFilteredQuery = this.listingRepository
       .createQueryBuilder("listings")
       .select("listings.id", "listings_id")
       .leftJoin("listings.property", "property")
-      .leftJoin("property.units", "units")
-      .leftJoin("units.unitType", "unitTypeRef")
       .leftJoin("property.buildingAddress", "buildingAddress")
       .leftJoin("listings.unitsSummary", "unitsSummary")
+      .leftJoin("unitsSummary.unitType", "summaryUnitType")
       .leftJoin("listings.reservedCommunityType", "reservedCommunityType")
       .groupBy("listings.id")
       .orderBy({ "listings.id": "DESC" })
@@ -73,7 +72,7 @@ export class ListingsService {
       .orderBy({
         "listings.applicationDueDate": "ASC",
         "listings.applicationOpenDate": "DESC",
-        "units.max_occupancy": "ASC",
+        "unitsSummary.max_occupancy": "ASC",
       })
       .andWhere("listings.id IN (" + innerFilteredQuery.getQuery() + ")")
       // Set the inner WHERE params on the outer query, as noted in the TypeORM docs.


### PR DESCRIPTION
## Issue

- Closes #530 

## Description

Migrates existing filters to query the units summary table and not the units table.
Removes the units table join from the filter query.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Start the backend locally and run:
`http://localhost:3100/listings?page=1&limit=10&filter[$comparison]=%3E=&filter[bedrooms]=1&filter[$comparison]=%3C=&filter[maxRent]=600`

This previously would have mistakenly returned one listing, but now correctly returns no listings.

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
