### PR TITLE
Pre-render first page of listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
   - Filtering by rent price ([#531](https://github.com/CityOfDetroit/bloom/pull/531))
   - UI for adding / editing units summaries ([#475](https://github.com/CityOfDetroit/bloom/pull/475))
   - Validate listing edit form ([#535](https://github.com/CityOfDetroit/bloom/pull/535))
+  - Pre-render first page of listings ([#540](https://github.com/CityOfDetroit/bloom/pull/540))
 
 ## Detroit Team M10
 


### PR DESCRIPTION
## Issue

- Closes #149 

## Description

Pre-renders the first (unfiltered) page of listings. Logic proceeds as follows:
- If the url isn't readable yet (`router.query` is a hook), display the loading message. This is to avoid displaying data before we've determined what the filters are.
- If the url has filters, it isn't the first page, or we're already dynamically fetching data, dynamically fetch data.
- If there aren't any filters and it's the first page, and we haven't fetched anything yet, use the static listing data.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
