### PR TITLE
Fix the ordering of unit summaries returned by `GET /listings`

### DIFF
--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -325,7 +325,11 @@ describe("ListingsService", () => {
 
       // The full query is additionally ordered by listing.unitsSummary.unitType.numBedrooms
       expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledTimes(1)
-      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith("summaryUnitType.num_bedrooms", "ASC", "NULLS LAST")
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith(
+        "summaryUnitType.num_bedrooms",
+        "ASC",
+        "NULLS LAST"
+      )
     })
   })
 })

--- a/backend/core/src/listings/listings.service.spec.ts
+++ b/backend/core/src/listings/listings.service.spec.ts
@@ -70,6 +70,7 @@ const mockInnerQueryBuilder = {
   select: jest.fn().mockReturnThis(),
   leftJoin: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
+  addOrderBy: jest.fn().mockReturnThis(),
   groupBy: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   offset: jest.fn().mockReturnThis(),
@@ -85,6 +86,7 @@ const mockQueryBuilder = {
   andWhere: jest.fn().mockReturnThis(),
   setParameters: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
+  addOrderBy: jest.fn().mockReturnThis(),
   getMany: jest.fn().mockReturnValue(mockListings),
 }
 const mockListingsRepo = {
@@ -304,7 +306,7 @@ describe("ListingsService", () => {
   })
 
   describe("ListingsService.list sorting", () => {
-    it("orderBy should be called on both query builders with the same argument", async () => {
+    it("verify both queries have correct ORDER BY clauses", async () => {
       mockListingsRepo.createQueryBuilder
         .mockReturnValueOnce(mockInnerQueryBuilder)
         .mockReturnValueOnce(mockQueryBuilder)
@@ -320,6 +322,10 @@ describe("ListingsService", () => {
       // The full query must be ordered so that the ordering is applied within a page (if pagination is requested)
       expect(mockQueryBuilder.orderBy).toHaveBeenCalledTimes(1)
       expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(expectedOrderByArgument)
+
+      // The full query is additionally ordered by listing.unitsSummary.unitType.numBedrooms
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledTimes(1)
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith("summaryUnitType.num_bedrooms", "ASC", "NULLS LAST")
     })
   })
 })

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -26,7 +26,7 @@ export class ListingsService {
     @InjectRepository(Listing) private readonly listingRepository: Repository<Listing>,
     @InjectRepository(AmiChart) private readonly amiChartsRepository: Repository<AmiChart>,
     private readonly translationService: TranslationsService
-  ) {}
+  ) { }
 
   private getFullyJoinedQueryBuilder() {
     return getView(this.listingRepository.createQueryBuilder("listings"), "full").getViewQb()
@@ -79,6 +79,7 @@ export class ListingsService {
       // and substitues for the `:paramName` placeholders in the WHERE clause.)
       .setParameters(innerFilteredQuery.getParameters())
       .orderBy(getOrderByCondition())
+      .addOrderBy("summaryUnitType.num_bedrooms", "ASC", "NULLS LAST")
       .getMany()
 
     // get summarized units from view

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -26,7 +26,7 @@ export class ListingsService {
     @InjectRepository(Listing) private readonly listingRepository: Repository<Listing>,
     @InjectRepository(AmiChart) private readonly amiChartsRepository: Repository<AmiChart>,
     private readonly translationService: TranslationsService
-  ) { }
+  ) {}
 
   private getFullyJoinedQueryBuilder() {
     return getView(this.listingRepository.createQueryBuilder("listings"), "full").getViewQb()

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -286,16 +286,16 @@ describe("Listings", () => {
   })
 
   it("listing.unitsSummary should be sorted by number of bedrooms (ascending)", async () => {
-    const listings = await supertest(app.getHttpServer())
-      .get("/listings?limit=all")
-      .expect(200)
+    const listings = await supertest(app.getHttpServer()).get("/listings?limit=all").expect(200)
 
     for (const listing of listings.body.items) {
       if (listing.unitsSummary.length > 1) {
         for (let i = 0; i < listing.unitsSummary.length - 1; ++i) {
           const currentUnitsSummary = listing.unitsSummary[i]
           const nextUnitsSummary = listing.unitsSummary[i + 1]
-          expect(currentUnitsSummary.unitType.numBedrooms).toBeLessThanOrEqual(nextUnitsSummary.unitType.numBedrooms)
+          expect(currentUnitsSummary.unitType.numBedrooms).toBeLessThanOrEqual(
+            nextUnitsSummary.unitType.numBedrooms
+          )
         }
       }
     }

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -285,6 +285,22 @@ describe("Listings", () => {
     }
   })
 
+  it("listing.unitsSummary should be sorted by number of bedrooms (ascending)", async () => {
+    const listings = await supertest(app.getHttpServer())
+      .get("/listings?limit=all")
+      .expect(200)
+
+    for (const listing of listings.body.items) {
+      if (listing.unitsSummary.length > 1) {
+        for (let i = 0; i < listing.unitsSummary.length - 1; ++i) {
+          const currentUnitsSummary = listing.unitsSummary[i]
+          const nextUnitsSummary = listing.unitsSummary[i + 1]
+          expect(currentUnitsSummary.unitType.numBedrooms).toBeLessThanOrEqual(nextUnitsSummary.unitType.numBedrooms)
+        }
+      }
+    }
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
   })


### PR DESCRIPTION
## Issue

- Addresses #193

## Description

The full listings query returns at least one row per (listing, unit summary) pair, but before this change we didn't enforce any order for unit summary's within a single listing. The result was that the unit summary table in the listings page displayed unit types out of order:

![image](https://user-images.githubusercontent.com/8754454/132767107-65d1fb13-a764-4eea-8b99-0ccc18b5911a.png)

With this change, the backend returns unitSummary's in order (per listing), and the frontend reflects the fix:

![image](https://user-images.githubusercontent.com/8754454/132767196-7f9d9f96-8580-4ebe-ab17-f2f2609d2f5a.png)

Note: this `ORDER BY` clause is only being added to the full query (not the `innerFilteredQuery`) because the purpose of the `innerFilteredQuery` is just to return a bunch of listing IDs, and there are no unit summaries returned by that query.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [X] Desktop View
- [X] Mobile View
- `cd backend/core && yarn test`
- `cd backend/core && yarn test:e2e:local`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
