### PR TITLE
Add error message display in the zipcode filter.

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -233,7 +233,7 @@ const ListingsPage = () => {
               validation={{
                 validate: (value) => isValidZipCodeOrEmpty(value),
               }}
-              error={errors.zipCodeField}
+              error={errors?.[ListingFilterKeys.zipcode]}
               errorMessage={t("errors.multipleZipCodeError")}
               defaultValue={filterState?.zipcode}
             />


### PR DESCRIPTION
## Issue

- Closes #429

## Description

Changes the error check to use the name of the `Field` instead of the id. The errors were there and preventing the submission of the form, but they weren't being displayed because the error variable was being checked for the wrong property.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

Try to enter an incorrect value into the filter and see the error message being displayed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
