### PR TITLE
Fix default radio option for partners summary vs units view

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -75,6 +75,7 @@ export type FormListing = Omit<Listing, "countyCode"> & {
   arePostmarksConsidered?: boolean
   canApplicationsBeDroppedOff?: boolean
   canPaperApplicationsBePickedUp?: boolean
+  displaySummaryData?: string
   dueDateQuestion?: boolean
   lotteryDate?: {
     month: string
@@ -328,7 +329,7 @@ const formatFormData = (
 
   return {
     ...data,
-    disableUnitsAccordion: stringToBoolean(data.disableUnitsAccordion),
+    disableUnitsAccordion: stringToBoolean(data.displaySummaryData),
     units: units,
     preferences: preferences,
     buildingAddress: {

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -97,8 +97,8 @@ const FormUnits = ({
 
   const editUnitsView = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      // See below in disableUnitAccordionOptions for ids.
-      setShowUnitsSummary(e.target.id === "unitTypes")
+      // See below in showUnitsSummaryOptions for ids.
+      setShowUnitsSummary(e.target.id === "summaries")
     },
     [setShowUnitsSummary]
   )
@@ -222,16 +222,18 @@ const FormUnits = ({
     [unitsSummaries, editSummary]
   )
 
-  const disableUnitsAccordionOptions = [
+  const showUnitsSummaryOptions = [
     {
-      id: "unitTypes",
+      id: "summaries",
       label: t("listings.unit.unitTypes"),
       value: "true",
+      defaultChecked: showUnitsSummary
     },
     {
-      id: "individualUnits",
+      id: "units",
       label: t("listings.unit.individualUnits"),
       value: "false",
+      defaultChecked: !showUnitsSummary
     },
   ]
 
@@ -247,10 +249,10 @@ const FormUnits = ({
           <GridCell>
             <ViewItem label={t("listings.unitTypesOrIndividual")} className="mb-1" />
             <FieldGroup
-              name="disableUnitsAccordion"
+              name="displaySummaryData"
               type="radio"
               register={register}
-              fields={disableUnitsAccordionOptions}
+              fields={showUnitsSummaryOptions}
               fieldClassName="m-0"
               fieldGroupClassName="flex h-12 items-center"
               onChange={editUnitsView}

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -227,13 +227,13 @@ const FormUnits = ({
       id: "summaries",
       label: t("listings.unit.unitTypes"),
       value: "true",
-      defaultChecked: showUnitsSummary
+      defaultChecked: showUnitsSummary,
     },
     {
       id: "units",
       label: t("listings.unit.individualUnits"),
       value: "false",
-      defaultChecked: !showUnitsSummary
+      defaultChecked: !showUnitsSummary,
     },
   ]
 


### PR DESCRIPTION
## Description

Fixes a bug where the radio button to toggle between summaries / individual units in the partner portal wouldn't have a default selection.

![image](https://user-images.githubusercontent.com/83078310/133476063-68fa3f99-0de0-46ea-b706-17680dd321b7.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Edit a listing in the partner portal and see the default selected item.

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
