### PR TITLE
Add loading indicator on listings page

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -311,6 +311,9 @@ const ListingsPage = () => {
       </div>
       <LoadingOverlay isLoading={listingsLoading}>
         <>
+          {listingsLoading && (
+            <div className="container max-w-3xl my-4 px-4 py-10 content-start mx-auto" />
+          )}
           {!listingsLoading && !listingsError && listingsData?.meta.totalItems === 0 && (
             <div className="container max-w-3xl my-4 px-4 content-start mx-auto">
               <header>

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -18,6 +18,7 @@ import {
   imageUrlFromListing,
   getSummariesTableFromUnitsSummary,
   getSummariesTableFromUnitSummary,
+  LoadingOverlay,
 } from "@bloom-housing/ui-components"
 import { useForm } from "react-hook-form"
 import Layout from "../layouts/application"
@@ -308,27 +309,31 @@ const ListingsPage = () => {
           </Button>
         )}
       </div>
-      {!listingsLoading && !listingsError && listingsData?.meta.totalItems === 0 && (
-        <div className="container max-w-3xl my-4 px-4 content-start mx-auto">
-          <header>
-            <h2 className="page-header__title">{t("listingFilters.noResults")}</h2>
-            <p className="page-header__lead">{t("listingFilters.noResultsSubtitle")}</p>
-          </header>
-        </div>
-      )}
-      {!listingsLoading && (
-        <div>
-          {listingsData?.meta.totalItems > 0 && getListings(listingsData?.items)}
-          <AgPagination
-            totalItems={listingsData?.meta.totalItems}
-            totalPages={listingsData?.meta.totalPages}
-            currentPage={currentPage}
-            itemsPerPage={itemsPerPage}
-            quantityLabel={t("listings.totalListings")}
-            setCurrentPage={setQueryString}
-          />
-        </div>
-      )}
+      <LoadingOverlay isLoading={listingsLoading}>
+        <>
+          {!listingsLoading && !listingsError && listingsData?.meta.totalItems === 0 && (
+            <div className="container max-w-3xl my-4 px-4 content-start mx-auto">
+              <header>
+                <h2 className="page-header__title">{t("listingFilters.noResults")}</h2>
+                <p className="page-header__lead">{t("listingFilters.noResultsSubtitle")}</p>
+              </header>
+            </div>
+          )}
+          {!listingsLoading && (
+            <div>
+              {listingsData?.meta.totalItems > 0 && getListings(listingsData?.items)}
+              <AgPagination
+                totalItems={listingsData?.meta.totalItems}
+                totalPages={listingsData?.meta.totalPages}
+                currentPage={currentPage}
+                itemsPerPage={itemsPerPage}
+                quantityLabel={t("listings.totalListings")}
+                setCurrentPage={setQueryString}
+              />
+            </div>
+          )}
+        </>
+      </LoadingOverlay>
     </Layout>
   )
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -48,3 +48,7 @@ a.button.is-primary:hover {
   max-height: 80vh;
   overflow-y: auto;
 }
+
+.loading-overlay__spinner {
+  @apply bg-primary
+}

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -49,6 +49,6 @@ a.button.is-primary:hover {
   overflow-y: auto;
 }
 
-.loading-overlay__spinner {
-  @apply text-primary
+.loading-overlay__spinner circle {
+  stroke: $tailwind-primary
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -50,5 +50,5 @@ a.button.is-primary:hover {
 }
 
 .loading-overlay__spinner {
-  @apply bg-primary
+  @apply text-primary
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -50,5 +50,5 @@ a.button.is-primary:hover {
 }
 
 .loading-overlay__spinner circle {
-  stroke: $tailwind-primary
+  stroke: $tailwind-primary;
 }


### PR DESCRIPTION
## Issue

- Closes #486 

## Description

Adds a loading overlay to the listings page while the listings are being loaded.

![ad5ab7e4-624b-4d3e-bd62-a1c981116bbf](https://user-images.githubusercontent.com/83078310/133478147-56d73f54-7012-4afc-896d-16b55fa3e149.gif)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

The data usually loads too quickly to see the spinner. If you want to view it, go to `sites/public/lib/hooks` `useListingsData()` and change `listingsLoading: true`.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
