### PR TITLE
Fix errors in listing edit form

### DIFF
--- a/backend/core/src/units-summary/entities/units-summary.entity.ts
+++ b/backend/core/src/units-summary/entities/units-summary.entity.ts
@@ -34,13 +34,13 @@ class UnitsSummary {
   @Column({ nullable: true, type: "integer" })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsNumberString({}, { groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
   monthlyRentMin?: number | null
 
   @Column({ nullable: true, type: "integer" })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsNumberString({}, { groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
   monthlyRentMax?: number | null
 
   @Column({ nullable: true, type: "numeric", precision: 8, scale: 2 })

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -277,6 +277,7 @@ const formatFormData = (
     summary.totalCount = toNumberOrNull(summary.totalCount)
     summary.monthlyRentMin = toNumberOrNull(summary.monthlyRentMin)
     summary.monthlyRentMax = toNumberOrNull(summary.monthlyRentMax)
+    summary.amiPercentage = toNumberOrNull(summary.amiPercentage)
 
     if (!summary.sqFeetMin) {
       delete summary.sqFeetMin

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -193,7 +193,7 @@ const FormUnits = ({
         unitType: summary.unitType && t(`listings.unitTypes.${summary.unitType.name}`),
         amiPercentage: isDefined(summary.amiPercentage) ? `${summary.amiPercentage}%` : "",
         monthlyRent: formatRange(summary.monthlyRentMin, summary.monthlyRentMax, "$"),
-        sqFeet: formatRange(summary.sqFeetMin, summary.sqFeetMax, "$"),
+        sqFeet: formatRange(summary.sqFeetMin, summary.sqFeetMax, ""),
         priorityType: summary.priorityType?.name,
         occupancy: formatRange(summary.minOccupancy, summary.maxOccupancy, ""),
         totalAvailable: summary.totalAvailable,


### PR DESCRIPTION
## Issue

- Closes #576 

## Description

Fixes the following issues:
- Incorrect validation of min/max rent fields (validating a number as a string) was causing failures when submitting listing edits
- AMI % was being saved as a string when it's a number in the database
- The `Sq Feet` column in the partner view of UnitsSummaries had a "$" prefix

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Navigate to the partner portal and add a summary with min/max rent.

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
