### PR TITLE
Remove minimum income from FE tables/forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project will be documented in this file. The format 
   - Backend Filtering by AMI ([#532](https://github.com/CityOfDetroit/bloom/pull/532))
   - Add backend listing sorting ([#542](https://github.com/CityOfDetroit/bloom/pull/542) and [#548](https://github.com/CityOfDetroit/bloom/pull/548))
 
+- Removed:
+
+  - Removed minimum income from frontend forms and tables ([#578](https://github.com/CityOfDetroit/bloom/pull/578))
+
 ## Detroit Team M10
 
 - Fixed:

--- a/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
@@ -337,20 +337,6 @@ const UnitsSummaryForm = ({
           {rentType === "fixed" && (
             <>
               <GridCell>
-                <ViewItem label={t("t.minimumIncome")}>
-                  <Field
-                    id="minimumIncomeMin"
-                    name="minimumIncomeMin"
-                    label={t("t.minimumIncome")}
-                    placeholder="0.00"
-                    register={register}
-                    type="number"
-                    prepend="$"
-                    readerOnly
-                  />
-                </ViewItem>
-              </GridCell>
-              <GridCell>
                 <ViewItem label={t("listings.unitsSummary.monthlyRentMin")}>
                   <Field
                     id="monthlyRentMin"
@@ -366,6 +352,8 @@ const UnitsSummaryForm = ({
                     validation={{ required: true }}
                   />
                 </ViewItem>
+              </GridCell>
+              <GridCell>
                 <ViewItem label={t("listings.unitsSummary.monthlyRentMax")}>
                   <Field
                     id="monthlyRentMax"

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -65,8 +65,8 @@ const getListingTableData = (listing: Listing) => {
 const getListings = (listings: Listing[]) => {
   const unitSummariesHeaders = {
     unitType: t("t.unitType"),
-    minimumIncome: t("t.minimumIncome"),
     rent: t("t.rent"),
+    availability: t("t.availability"),
   }
   return listings.map((listing: Listing, index) => {
     return (

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -45,7 +45,6 @@ export const ListingView = (props: ListingProps) => {
 
   const unitSummariesHeaders = {
     unitType: t("t.unitType"),
-    minimumIncome: t("t.minimumIncome"),
     rent: t("t.rent"),
     availability: t("t.availability"),
   }

--- a/ui-components/src/helpers/tableSummaries.tsx
+++ b/ui-components/src/helpers/tableSummaries.tsx
@@ -3,43 +3,14 @@ import { t } from "./translator"
 import { UnitSummary, UnitsSummary } from "@bloom-housing/backend-core/types"
 import { GroupedTableGroup } from "../tables/GroupedTable"
 
-export const getSummaryRow = (
+const getSummaryRow = (
   totalAvailable: number,
-  minIncomeRangeMin?: string,
-  minIncomeRangeMax?: string,
   rentRangeMin?: string,
   rentRangeMax?: string,
   rentAsPercentIncomeRangeMin?: string,
   rentAsPercentIncomeRangeMax?: string,
   unitTypeName?: string
 ) => {
-  let minIncome = <></>
-  if (minIncomeRangeMin == undefined && minIncomeRangeMax == undefined) {
-    //TODO(#345): figure out what to display when there's no data
-    minIncome = <strong>{t("t.call")}</strong>
-  } else if (minIncomeRangeMin == minIncomeRangeMax || minIncomeRangeMax == undefined) {
-    minIncome = (
-      <>
-        <strong>{minIncomeRangeMin}</strong>
-        {t("t.perMonth")}
-      </>
-    )
-  } else if (minIncomeRangeMin == undefined) {
-    minIncome = (
-      <>
-        <strong>{minIncomeRangeMax}</strong>
-        {t("t.perMonth")}
-      </>
-    )
-  } else {
-    minIncome = (
-      <>
-        <strong>{minIncomeRangeMin}</strong> {t("t.to")} <strong>{minIncomeRangeMax}</strong>
-        {t("t.perMonth")}
-      </>
-    )
-  }
-
   const getRent = (rentMin?: string, rentMax?: string, percent = false) => {
     const unit = percent ? `% ${t("t.income")}` : ` ${t("t.perMonth")}`
     if (rentMin == undefined && rentMax == undefined) {
@@ -76,7 +47,6 @@ export const getSummaryRow = (
 
   return {
     unitType: <strong>{t(`listings.unitTypes.${unitTypeName}`)}</strong>,
-    minimumIncome: <>{minIncome}</>,
     rent: <>{rent}</>,
     availability: (
       <>
@@ -99,8 +69,6 @@ export const getSummariesTableFromUnitSummary = (summaries: UnitSummary[]) => {
     const unitSummaries = summaries.map((unitSummary) => {
       return getSummaryRow(
         unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
-        unitSummary.minIncomeRange.min,
-        unitSummary.minIncomeRange.max,
         unitSummary.rentRange.min,
         unitSummary.rentRange.max,
         unitSummary.rentAsPercentIncomeRange.min
@@ -128,8 +96,6 @@ export const getSummariesTableFromUnitsSummary = (summaries: UnitsSummary[]) => 
     const unitSummaries = summaries.map((unitSummary) => {
       return getSummaryRow(
         unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
-        unitSummary.minimumIncomeMin,
-        unitSummary.minimumIncomeMax,
         unitSummary.monthlyRentMin?.toString(),
         unitSummary.monthlyRentMax?.toString(),
         unitSummary.monthlyRentAsPercentOfIncome,


### PR DESCRIPTION
## Issue

- Closes #554 

## Description

Removes minimum income from a few places:
- Partner portal listing add / edit forms
- Summary table in main listings view
- Summary table in individual listing view

In the main view summary tables, I replaced the column with an Availability column, because it was easy to hook up and is the column we already display in the individual listing view.

Partner form before:
![image](https://user-images.githubusercontent.com/83078310/133675222-c49f08a7-f1ea-4732-921e-45b952f6c470.png)

After:
![image](https://user-images.githubusercontent.com/83078310/133675239-2933b54e-df50-4036-94c5-88ab492f368c.png)

New summary table in mobile and desktop:
![image](https://user-images.githubusercontent.com/83078310/133675290-b68934d7-419e-4bd9-884b-b52fbe81e9b5.png)

![image](https://user-images.githubusercontent.com/83078310/133675304-a935ab99-4df6-4546-8cba-db43dffb2dba.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
