### PR TITLE
Change "View on Map" link font size

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -110,7 +110,7 @@ export const ListingView = (props: ListingProps) => {
             {oneLineAddress}
           </p>
           <p className="text-gray-700 text-base">{listing.developer}</p>
-          <p className="text-xs">
+          <p className="text-xl">
             <a href={googleMapsHref} target="_blank" aria-label="Opens in new window">
               {t("t.viewOnMap")}
             </a>


### PR DESCRIPTION
## Issue

- Closes # (issue)
- Addresses #525 
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This change updates the size of the "View on Map" link from XS to XL.
![image](https://user-images.githubusercontent.com/82653098/133791883-bb2bd609-aa44-4e60-8e53-f9b3c36ead4e.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?
Open an individual listing and view the map link size.

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
