### PR TITLE
Remove Feedback banner

### DIFF
--- a/sites/public/layouts/application.tsx
+++ b/sites/public/layouts/application.tsx
@@ -34,7 +34,7 @@ const Layout = (props) => {
         <SiteHeader
           skip={t("nav.skip")}
           logoSrc="/images/detroit-logo.png"
-          notice={<div dangerouslySetInnerHTML={getTranslationMarkup("nav.getFeedback")}></div>}
+          notice=""
           title={t("nav.siteTitle")}
           language={{
             list: languages,

--- a/sites/public/tailwind.config.js
+++ b/sites/public/tailwind.config.js
@@ -9,14 +9,14 @@ const bloomTheme = cloneDeep(require("@bloom-housing/ui-components/tailwind.conf
 // and the [Detroit color scheme](https://detroitmi.gov/sites/detroitmi.localhost/files/2021-06/DetroitOpportunity_12.01%20%282%29.pdf?#page=14)
 bloomTheme.theme.colors["primary-darker"] = "#004445"
 bloomTheme.theme.colors["primary-dark"] = "#004445"
-bloomTheme.theme.colors.primary = "#238578"
+bloomTheme.theme.colors.primary = "#279989"
 bloomTheme.theme.colors["primary-light"] = "#F2F2F2"
 bloomTheme.theme.colors["primary-lighter"] = "#F2F2F2"
 bloomTheme.theme.colors["gray-700"] = "#000000"
 bloomTheme.theme.colors["gray-800"] = "#18252A"
 bloomTheme.theme.colors["gray-950"] = "#000000"
 bloomTheme.theme.colors.warn = "#feb70d"
-bloomTheme.theme.colors["accent-cool"] = "#238578"
+bloomTheme.theme.colors["accent-cool"] = "#279989"
 // The progress bar "done" sections color
 bloomTheme.theme.colors.lush = "#feb70d"
 bloomTheme.theme.fontFamily.sans = [

--- a/sites/public/tailwind.config.js
+++ b/sites/public/tailwind.config.js
@@ -9,14 +9,14 @@ const bloomTheme = cloneDeep(require("@bloom-housing/ui-components/tailwind.conf
 // and the [Detroit color scheme](https://detroitmi.gov/sites/detroitmi.localhost/files/2021-06/DetroitOpportunity_12.01%20%282%29.pdf?#page=14)
 bloomTheme.theme.colors["primary-darker"] = "#004445"
 bloomTheme.theme.colors["primary-dark"] = "#004445"
-bloomTheme.theme.colors.primary = "#279989"
+bloomTheme.theme.colors.primary = "#238578"
 bloomTheme.theme.colors["primary-light"] = "#F2F2F2"
 bloomTheme.theme.colors["primary-lighter"] = "#F2F2F2"
 bloomTheme.theme.colors["gray-700"] = "#000000"
 bloomTheme.theme.colors["gray-800"] = "#18252A"
 bloomTheme.theme.colors["gray-950"] = "#000000"
 bloomTheme.theme.colors.warn = "#feb70d"
-bloomTheme.theme.colors["accent-cool"] = "#279989"
+bloomTheme.theme.colors["accent-cool"] = "#238578"
 // The progress bar "done" sections color
 bloomTheme.theme.colors.lush = "#feb70d"
 bloomTheme.theme.fontFamily.sans = [


### PR DESCRIPTION
## Issue

- Closes #220 

## Description

Removes feedback link and message in the header on all pages
![image](https://user-images.githubusercontent.com/82653098/133800643-a91953de-94f6-4600-9a8b-ab7af359f11f.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

View the homepage and run a Lighthouse test for accessibility.  Header banner no longer is flagged for contrast.

- [x] Desktop View

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
