### PR TITLE
Build the production site for Cypress tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ jobs:
         - cd backend/core
         - yarn nest start &
         - cd ../../sites/public
-        - yarn dev &
+        - yarn build
+        - yarn start &
         - yarn wait-on "http-get://localhost:3000" && yarn cypress run
         - kill $(jobs -p) || true
     - stage: longer tests


### PR DESCRIPTION
In #593 I noticed that building the production site actually sped up the overall time for Cypress tests in Travis because the production site responds faster (see the difference between the partner Cypress tests with production build and the public Cypress tests with dev build [here](https://app.travis-ci.com/github/CityOfDetroit/bloom/builds/238135030)). So, apply the same to the public site.