### PR TITLE
Fix the inconsistent spacing between navbar items

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -31,6 +31,9 @@ h1.form-card__header_title {
   text-transform: capitalize;
 }
 
+// For the eligibility questionnaire, there are five headers, so give each 20% of the full navbar
+// width. (If we reuse this class for other navigation UI elements, with a different number of
+// navbar items, we'll need to refactor this.)
 li.progress-nav__item {
   width: 20%;
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -31,6 +31,10 @@ h1.form-card__header_title {
   text-transform: capitalize;
 }
 
+li.progress-nav__item {
+  width: 20%;
+}
+
 // Body text should have normal font weight
 .field-note {
   @apply font-normal;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/8754454/134402729-3f0e28bb-cdb2-45b2-b3fb-2f0dcf085ee7.png)

After:

![image](https://user-images.githubusercontent.com/8754454/134402817-36143e8b-d6dc-41ba-8cde-cf1ee3ca538d.png)

But on mobile (or for narrow window widths), it will still do inconsistent spacing so that each navbar item gets space according to how wide the text is:

![image](https://user-images.githubusercontent.com/8754454/134403249-ccc3fbd3-65d2-4bbf-85e2-88ebea808663.png)

AFAICT our codebase only uses the `ProgressNav` for the eligibility questionnaire, so the entirety of this change should be displayed in those screenshots above.