### PR TITLE
Disable default href behavior in nav bar

### DIFF
--- a/ui-components/src/navigation/ProgressNav.tsx
+++ b/ui-components/src/navigation/ProgressNav.tsx
@@ -9,7 +9,7 @@ const ProgressNavItem = (props: {
   currentPageSection: number
   completedSections: number
   label: string
-  route: string
+  route: string | null
 }) => {
   const router = useRouter()
 
@@ -27,7 +27,12 @@ const ProgressNavItem = (props: {
       <a
         aria-disabled={bgColor == "is-disabled"}
         href={"#"}
-        onClick={() => router.push(props.route)}
+        onClick={(e) => {
+          e.preventDefault()
+          if (props.route) {
+            router.push(props.route)
+          }
+        }}
       >
         {props.label}
       </a>
@@ -53,7 +58,7 @@ const ProgressNav = (props: {
             currentPageSection={props.currentPageSection}
             completedSections={props.completedSections}
             label={label}
-            route={props.routes ? props.routes[i] : "#"}
+            route={props.routes ? props.routes[i] : null}
           />
         ))}
       </ul>

--- a/ui-components/src/navigation/ProgressNav.tsx
+++ b/ui-components/src/navigation/ProgressNav.tsx
@@ -28,6 +28,7 @@ const ProgressNavItem = (props: {
         aria-disabled={bgColor == "is-disabled"}
         href={"#"}
         onClick={(e) => {
+          // Prevent default event behavior, which would route using href and not onClick.
           e.preventDefault()
           if (props.route) {
             router.push(props.route)


### PR DESCRIPTION
## Issue

- Closes #442 

## Description

Disables the default `href` behavior in the nav bar, which is move relevantly used in the eligibility questionnaire. This prevents the url from being appended with a `#` when clicking on a nav link, which caused a user to have to click "back" twice if they wanted to navigate back (once to lose the trailing `#`, and a second time to get back to the previous page).

Example of clicking a nav link and not getting an appended `#`:

![image](https://user-images.githubusercontent.com/83078310/134405198-8b3210fb-d0a9-45b9-b66d-c1426ef0b9ce.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Go to the eligibility questionnaire, click through past the "welcome" tab, then click on a prior nav tab. The url should not have a trailing `#`, and clicking the back button should work on the first click.

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
