### PR TITLE
Fix default rent type bug

### DIFF
--- a/sites/partners/lib/helpers.ts
+++ b/sites/partners/lib/helpers.ts
@@ -115,12 +115,7 @@ export const getRentType = (unit: TempUnit): string | null => {
 }
 
 export const getRentTypeFromUnitsSummary = (summary: TempUnitsSummary): string | null => {
-  if (
-    summary?.minimumIncomeMin ||
-    summary?.minimumIncomeMax ||
-    summary?.monthlyRentMin ||
-    summary?.monthlyRentMax
-  ) {
+  if (summary?.monthlyRentMin || summary?.monthlyRentMax) {
     return "fixed"
   } else if (summary?.monthlyRentAsPercentOfIncome) {
     return "percentage"

--- a/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
@@ -56,7 +56,6 @@ const UnitsSummaryForm = ({
       minOccupancy: current?.minOccupancy,
       maxOccupancy: current?.maxOccupancy,
       amiPercentage: current?.amiPercentage,
-      minimumIncomeMin: current?.minimumIncomeMin,
       monthlyRentMin: current?.monthlyRentMin,
       monthlyRentMax: current?.monthlyRentMax,
       totalCount: current?.totalCount,
@@ -93,7 +92,6 @@ const UnitsSummaryForm = ({
     if (data.rentType === "fixed") {
       delete data.monthlyRentAsPercentOfIncome
     } else if (data.rentType === "percentage") {
-      data.minimumIncomeMin = "0"
       delete data.monthlyRentMin
       delete data.monthlyRentMax
     }

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -17,6 +17,7 @@ import UnitForm from "../UnitForm"
 import { useFormContext } from "react-hook-form"
 import { TempUnit, TempUnitsSummary } from "../"
 import UnitsSummaryForm from "../UnitsSummaryForm"
+import { UnitsSummary } from "@bloom-housing/backend-core/types"
 
 type UnitProps = {
   units: TempUnit[]
@@ -175,6 +176,15 @@ const FormUnits = ({
     [editUnit, units]
   )
 
+  const getRentFromSummary = (summary: UnitsSummary) => {
+    if (summary.monthlyRentMin || summary.monthlyRentMax) {
+      return formatRange(summary.monthlyRentMin, summary.monthlyRentMax, "$")
+    }
+    if (summary.monthlyRentAsPercentOfIncome) {
+      return `${summary.monthlyRentAsPercentOfIncome}%`
+    }
+  }
+
   function saveUnitsSummary(newSummary: TempUnitsSummary) {
     const exists = unitsSummaries.some((summary) => summary.tempId === newSummary.tempId)
     if (exists) {
@@ -191,7 +201,7 @@ const FormUnits = ({
       unitsSummaries?.map((summary) => ({
         unitType: summary.unitType && t(`listings.unitTypes.${summary.unitType.name}`),
         amiPercentage: isDefined(summary.amiPercentage) ? `${summary.amiPercentage}%` : "",
-        monthlyRent: formatRange(summary.monthlyRentMin, summary.monthlyRentMax, "$"),
+        monthlyRent: getRentFromSummary(summary),
         sqFeet: formatRange(summary.sqFeetMin, summary.sqFeetMax, ""),
         priorityType: summary.priorityType?.name,
         occupancy: formatRange(summary.minOccupancy, summary.maxOccupancy, ""),


### PR DESCRIPTION
## Issue

- Closes #586 

## Description

Fixes a bug where legacy `minimumIncomeMin` was causing the Rent Type selector in the units summary form to always default to "Fixed Amount".

Also added income % to the "Rent" column in the summary table. Previously, only fixed rent amounts were showing here. Here is an example of both formats with the changes applied:

![image](https://user-images.githubusercontent.com/83078310/134409698-eac53b07-bb74-483b-acb6-73149d393c1c.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Create a new summary with rent type "% of Income" and save. Open the form to edit the summary you just created and see that the "% of Income" radio is selected by default.

- [x] Desktop View
- [ ] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
