### PR TITLE
Decouple frontend filter state storage from ListingFilterParams

### DIFF
--- a/sites/public/lib/hooks.ts
+++ b/sites/public/lib/hooks.ts
@@ -10,13 +10,9 @@ import {
   openDateState,
   t,
   encodeToBackendFilterArray,
+  ListingFilterState,
 } from "@bloom-housing/ui-components"
-import {
-  Listing,
-  ListingReviewOrder,
-  ListingFilterParams,
-  OrderByFieldsEnum,
-} from "@bloom-housing/backend-core/types"
+import { Listing, ListingReviewOrder, OrderByFieldsEnum } from "@bloom-housing/backend-core/types"
 import { AppSubmissionContext } from "./AppSubmissionContext"
 import { ParsedUrlQuery } from "querystring"
 
@@ -52,7 +48,7 @@ const listingsFetcher = function () {
     url: string,
     page: number,
     limit: number,
-    filters: ListingFilterParams,
+    filters: ListingFilterState,
     orderBy: OrderByFieldsEnum
   ) => {
     const res = await axios.get(url, {
@@ -74,7 +70,7 @@ const listingsFetcher = function () {
 export function useListingsData(
   pageIndex: number,
   limit = 10,
-  filters: ListingFilterParams,
+  filters: ListingFilterState,
   orderBy: OrderByFieldsEnum
 ) {
   const { data, error } = useSWR(

--- a/sites/public/pages/eligibility/income.tsx
+++ b/sites/public/pages/eligibility/income.tsx
@@ -14,16 +14,13 @@ import {
   AppearanceStyleType,
   encodeToFrontendFilterString,
   Select,
+  ListingFilterState,
 } from "@bloom-housing/ui-components"
 import { useForm } from "react-hook-form"
 import { EligibilityContext } from "../../lib/EligibilityContext"
 import { eligibilityRoute } from "../../lib/helpers"
 import FormBackLink from "../../src/forms/applications/FormBackLink"
 import { useRouter } from "next/router"
-import {
-  EnumListingFilterParamsComparison,
-  ListingFilterParams,
-} from "@bloom-housing/backend-core/types"
 
 const EligibilityIncome = () => {
   const router = useRouter()
@@ -52,10 +49,7 @@ const EligibilityIncome = () => {
   }
 
   function getFilterUrl() {
-    const params: ListingFilterParams = {
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
-    }
+    const params: ListingFilterState = {}
 
     if (eligibilityRequirements.age < SENIOR_AGE) {
       params.seniorHousing = false

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -19,6 +19,8 @@ import {
   getSummariesTableFromUnitsSummary,
   getSummariesTableFromUnitSummary,
   LoadingOverlay,
+  ListingFilterState,
+  FrontendListingFilterStateKeys,
 } from "@bloom-housing/ui-components"
 import { useForm } from "react-hook-form"
 import Layout from "../layouts/application"
@@ -27,9 +29,7 @@ import React, { useEffect, useState } from "react"
 import { useRouter } from "next/router"
 import { useListingsData } from "../lib/hooks"
 import {
-  ListingFilterKeys,
   AvailabilityFilterEnum,
-  ListingFilterParams,
   OrderByFieldsEnum,
   Listing,
   Address,
@@ -102,7 +102,7 @@ const ListingsPage = () => {
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState<number>(1)
-  const [filterState, setFilterState] = useState<ListingFilterParams>()
+  const [filterState, setFilterState] = useState<ListingFilterState>()
   const itemsPerPage = 10
 
   // Filter state
@@ -181,7 +181,7 @@ const ListingsPage = () => {
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { handleSubmit, register, errors } = useForm()
-  const onSubmit = (data: ListingFilterParams) => {
+  const onSubmit = (data: ListingFilterState) => {
     setFilterModalVisible(false)
     setQueryString(/*page=*/ 1, data)
   }
@@ -204,7 +204,7 @@ const ListingsPage = () => {
             <p className="field-note mb-4">{t("listingFilters.modalHeader")}</p>
             <Select
               id={"availability"}
-              name={"availability"}
+              name={FrontendListingFilterStateKeys.availability}
               label={t("listingFilters.availability")}
               register={register}
               controlClassName="control"
@@ -213,7 +213,7 @@ const ListingsPage = () => {
             />
             <Select
               id="unitOptions"
-              name={ListingFilterKeys.bedrooms}
+              name={FrontendListingFilterStateKeys.bedrooms}
               label={t("listingFilters.bedrooms")}
               register={register}
               controlClassName="control"
@@ -222,7 +222,7 @@ const ListingsPage = () => {
             />
             <Field
               id="zipCodeField"
-              name={ListingFilterKeys.zipcode}
+              name={FrontendListingFilterStateKeys.zipcode}
               label={t("listingFilters.zipCode")}
               register={register}
               controlClassName="control"
@@ -230,7 +230,7 @@ const ListingsPage = () => {
               validation={{
                 validate: (value) => isValidZipCodeOrEmpty(value),
               }}
-              error={errors?.[ListingFilterKeys.zipcode]}
+              error={errors?.[FrontendListingFilterStateKeys.zipcode]}
               errorMessage={t("errors.multipleZipCodeError")}
               defaultValue={filterState?.zipcode}
             />
@@ -238,7 +238,7 @@ const ListingsPage = () => {
             <div className="flex flex-row">
               <Field
                 id="minRent"
-                name={ListingFilterKeys.minRent}
+                name={FrontendListingFilterStateKeys.minRent}
                 register={register}
                 type="number"
                 placeholder={t("t.min")}
@@ -248,7 +248,7 @@ const ListingsPage = () => {
               <div className="flex items-center p-3">{t("t.to")}</div>
               <Field
                 id="maxRent"
-                name={ListingFilterKeys.maxRent}
+                name={FrontendListingFilterStateKeys.maxRent}
                 register={register}
                 type="number"
                 placeholder={t("t.max")}

--- a/ui-components/__tests__/helpers/filters.test.ts
+++ b/ui-components/__tests__/helpers/filters.test.ts
@@ -3,6 +3,7 @@ import {
   encodeToBackendFilterArray,
   encodeToFrontendFilterString,
   decodeFiltersFromFrontendUrl,
+  ListingFilterState,
 } from "../../src/helpers/filters"
 import { parse } from "querystring"
 import {
@@ -15,102 +16,92 @@ afterEach(cleanup)
 
 describe("encode backend filter array", () => {
   it("should handle single filter", () => {
-    const filter: ListingFilterParams = {
-      status: EnumListingFilterParamsStatus.active,
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filter: ListingFilterState = {
+      zipcode: "48226",
     }
     expect(encodeToBackendFilterArray(filter)).toEqual([
       {
-        $comparison: EnumListingFilterParamsComparison["="],
-        status: EnumListingFilterParamsStatus.active,
+        $comparison: EnumListingFilterParamsComparison["IN"],
+        zipcode: "48226",
       },
     ])
   })
+
   it("should handle multiple filters", () => {
-    const filter: ListingFilterParams = {
-      name: "Name",
-      status: EnumListingFilterParamsStatus.active,
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filter: ListingFilterState = {
+      bedrooms: "3",
+      zipcode: "48226",
     }
     expect(encodeToBackendFilterArray(filter)).toEqual([
       {
-        $comparison: EnumListingFilterParamsComparison["="],
-        name: "Name",
+        $comparison: EnumListingFilterParamsComparison[">="],
+        bedrooms: "3"
       },
       {
-        $comparison: EnumListingFilterParamsComparison["="],
-        status: EnumListingFilterParamsStatus.active,
+        $comparison: EnumListingFilterParamsComparison["IN"],
+        zipcode: "48226",
       },
     ])
   })
 })
 
-describe("encode frontend filter string", () => {
+describe("encode filter state as frontend querystring", () => {
   it("should handle single filter", () => {
-    const filter: ListingFilterParams = {
-      status: EnumListingFilterParamsStatus.active,
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filter: ListingFilterState = {
+      zipcode: "48226",
     }
-    expect(encodeToFrontendFilterString(filter)).toBe("&status=active")
+    expect(encodeToFrontendFilterString(filter)).toBe("&zipcode=48226")
   })
+
   it("should handle multiple filters", () => {
-    const filter: ListingFilterParams = {
-      name: "Name",
-      status: EnumListingFilterParamsStatus.active,
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filter: ListingFilterState = {
+      bedrooms: "3",
+      zipcode: "48226",
     }
-    expect(encodeToFrontendFilterString(filter)).toBe("&name=Name&status=active")
+    expect(encodeToFrontendFilterString(filter)).toBe("&bedrooms=3&zipcode=48226")
   })
+
   it("should exclude empty filters", () => {
-    const filter: ListingFilterParams = {
-      name: "Name",
-      status: undefined,
+    const filter: ListingFilterState = {
+      bedrooms: "3",
       zipcode: "",
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
     }
-    expect(encodeToFrontendFilterString(filter)).toBe("&name=Name")
+    expect(encodeToFrontendFilterString(filter)).toBe("&bedrooms=3")
   })
 })
 
-describe("get filter from parsed url", () => {
+describe("get filter state from parsed url", () => {
   it("should handle single filter", () => {
-    const filterString = parse("localhost:3000/listings?page=1&status=active")
-    const expected: ListingFilterParams = {
-      status: EnumListingFilterParamsStatus.active,
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filterString = parse("localhost:3000/listings?page=1&zipcode=48226")
+    const expected: ListingFilterState = {
+      zipcode: "48226"
     }
     expect(decodeFiltersFromFrontendUrl(filterString)).toStrictEqual(expected)
   })
+
   it("should handle multiple filters", () => {
-    const filterString = parse("localhost:3000/listings?page=1&status=active&name=Name")
-    const expected: ListingFilterParams = {
-      status: EnumListingFilterParamsStatus.active,
-      name: "Name",
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filterString = parse("localhost:3000/listings?page=1&bedrooms=3&zipcode=48226")
+    const expected: ListingFilterState = {
+      bedrooms: "3",
+      zipcode: "48226",
     }
     expect(decodeFiltersFromFrontendUrl(filterString)).toStrictEqual(expected)
   })
+
   it("should handle no filters", () => {
     const filterString = parse("localhost:3000/listings?page=1")
     expect(decodeFiltersFromFrontendUrl(filterString)).toBe(undefined)
   })
+
   it("should handle no known filter keys", () => {
     const filterString = parse("localhost:3000/listings?page=1&unknown=blah")
     expect(decodeFiltersFromFrontendUrl(filterString)).toBe(undefined)
   })
+
   it("should handle some known filters", () => {
-    const filterString = parse("localhost:3000/listings?page=1&unknown=blah&name=Name")
-    const expected: ListingFilterParams = {
-      name: "Name",
-      // $comparison is a required field even though it won't be used on the frontend. Will be fixed in #484.
-      $comparison: EnumListingFilterParamsComparison.NA,
+    const filterString = parse("localhost:3000/listings?page=1&unknown=blah&zipcode=48226")
+    const expected: ListingFilterState = {
+      zipcode: "48226",
     }
     expect(decodeFiltersFromFrontendUrl(filterString)).toStrictEqual(expected)
   })

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -1,10 +1,21 @@
 import {
   EnumListingFilterParamsComparison,
+  AvailabilityFilterEnum,
   ListingFilterKeys,
-  ListingFilterParams,
 } from "@bloom-housing/backend-core/types"
 import { ParsedUrlQuery } from "querystring"
 
+// TODO: Refactor filter state storage strategy
+// Currently, the knowledge of "what a filter is" is spread across multiple
+// places: getComparisonForFilter(), ListingFilterState, FrontendListingFilterStateKeys,
+// ListingFilterKeys, the encode/decode methods, and the various enums with options
+// for the filters. It could be worth unifying this into a ListingFilterStateManager
+// class that can hold all this in one place. Work toward this is in
+// https://github.com/CityOfDetroit/bloom/pull/484, but was set aside.
+
+// On the frontend, we assume a filter will always use the same comparison. (For
+// example, that minRent will always use a >= comparison.) The backend doesn't
+// make this assumption, so we need to tell it what comparison to use.
 function getComparisonForFilter(filterKey: ListingFilterKeys) {
   switch (filterKey) {
     case ListingFilterKeys.name:
@@ -29,42 +40,57 @@ function getComparisonForFilter(filterKey: ListingFilterKeys) {
   }
 }
 
-export function encodeToBackendFilterArray(filterParams: ListingFilterParams) {
+// Define the keys we expect to see in the frontend URL. These are also used for
+// the filter state object, ListingFilterState.
+export const FrontendListingFilterStateKeys = { ...ListingFilterKeys }
+export interface ListingFilterState {
+  [FrontendListingFilterStateKeys.availability]?: string
+  [FrontendListingFilterStateKeys.bedrooms]?: string
+  [FrontendListingFilterStateKeys.zipcode]?: string
+  [FrontendListingFilterStateKeys.minRent]?: string
+  [FrontendListingFilterStateKeys.maxRent]?: string
+  [FrontendListingFilterStateKeys.seniorHousing]?: string
+}
+
+export function encodeToBackendFilterArray(filterState: ListingFilterState) {
   const filterArray = []
-  for (const filterType in filterParams) {
+  for (const filterType in filterState) {
+    // Only include things that are a backend filter type. The keys of
+    // ListingFilterState are a superset of ListingFilterKeys that may include
+    // keys not recognized by the backend, so we check against ListingFilterKeys
+    // here.
     if (filterType in ListingFilterKeys) {
       const comparison = getComparisonForFilter(ListingFilterKeys[filterType])
       filterArray.push({
         $comparison: comparison,
-        [filterType]: filterParams[filterType],
+        [filterType]: filterState[filterType],
       })
     }
   }
   return filterArray
 }
 
-export function encodeToFrontendFilterString(filterParams: ListingFilterParams) {
+export function encodeToFrontendFilterString(filterState: ListingFilterState) {
   let queryString = ""
-  for (const filterType in filterParams) {
-    const value = filterParams[filterType]
-    if (filterType in ListingFilterKeys && value !== undefined && value !== "") {
+  for (const filterType in filterState) {
+    const value = filterState[filterType]
+    if (filterType in FrontendListingFilterStateKeys && value !== undefined && value !== "") {
       queryString += `&${filterType}=${value}`
     }
   }
   return queryString
 }
 
-export function decodeFiltersFromFrontendUrl(query: ParsedUrlQuery) {
-  // ListingFilterParams must have a comparison, so set one here even though it's unused.
-  const filters: ListingFilterParams = {
-    $comparison: EnumListingFilterParamsComparison.NA,
-  }
+export function decodeFiltersFromFrontendUrl(
+  query: ParsedUrlQuery
+): ListingFilterState | undefined {
+  const filterState: ListingFilterState = {}
   let foundFilterKey = false
   for (const queryKey in query) {
-    if (queryKey in ListingFilterKeys) {
-      filters[queryKey] = query[queryKey]
+    if (queryKey in FrontendListingFilterStateKeys) {
+      filterState[queryKey] = query[queryKey]
       foundFilterKey = true
     }
   }
-  return foundFilterKey ? filters : undefined
+  return foundFilterKey ? filterState : undefined
 }

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -5,7 +5,7 @@ import {
 } from "@bloom-housing/backend-core/types"
 import { ParsedUrlQuery } from "querystring"
 
-// TODO: Refactor filter state storage strategy
+// TODO(#629): Refactor filter state storage strategy
 // Currently, the knowledge of "what a filter is" is spread across multiple
 // places: getComparisonForFilter(), ListingFilterState, FrontendListingFilterStateKeys,
 // ListingFilterKeys, the encode/decode methods, and the various enums with options

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -44,12 +44,12 @@ function getComparisonForFilter(filterKey: ListingFilterKeys) {
 // the filter state object, ListingFilterState.
 export const FrontendListingFilterStateKeys = { ...ListingFilterKeys }
 export interface ListingFilterState {
-  [FrontendListingFilterStateKeys.availability]?: string
-  [FrontendListingFilterStateKeys.bedrooms]?: string
+  [FrontendListingFilterStateKeys.availability]?: string | AvailabilityFilterEnum
+  [FrontendListingFilterStateKeys.bedrooms]?: string | number
   [FrontendListingFilterStateKeys.zipcode]?: string
-  [FrontendListingFilterStateKeys.minRent]?: string
-  [FrontendListingFilterStateKeys.maxRent]?: string
-  [FrontendListingFilterStateKeys.seniorHousing]?: string
+  [FrontendListingFilterStateKeys.minRent]?: string | number
+  [FrontendListingFilterStateKeys.maxRent]?: string | number
+  [FrontendListingFilterStateKeys.seniorHousing]?: string | boolean
 }
 
 export function encodeToBackendFilterArray(filterState: ListingFilterState) {


### PR DESCRIPTION
## Issue #625 

- Closes #625 
- [x] This change is a dependency for another issue

## Description
To unblock #581, we need to be able to set a frontend query param like `includeNulls`. This isn't a filter type, or a field on `ListingFilterParams`, so trying to use the backend `ListingFilterParams` to store frontend state doesn't work.

This does the minimal work necessary to decouple the frontend filter state storage from  `ListingFilterParams`, drawing on @elenm's work in #484 and my experiments in #545.

As of this PR, the concept of "what a filter is" is spread across multiple places:
- getComparisonForFilter()
- ListingFilterState
- FrontendListingFilterStateKeys
- ListingFilterKeys
- the encode/decode methods
- the various enums with options for the filters

It could be worth unifying this into a ListingFilterStateManager class that can hold all this in one place. Work toward this is in #484, but was set aside.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?
Try using the frontend filters, and run the tests.

- [x] Desktop View
- [x] Mobile View
- [x] Test A
- [x] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
