### PR TITLE
Fix other filters are ignored when custom filters are applied

### DIFF
--- a/backend/core/src/shared/filter/index.spec.ts
+++ b/backend/core/src/shared/filter/index.spec.ts
@@ -69,5 +69,31 @@ describe("FilterAdder", () => {
         addFilters([filter], filterTypeToFieldMap, mockQueryBuilder)
       }).toThrow("Comparison Not Implemented")
     })
+
+    it("should add both custom and standard filters", () => {
+      const filters = [
+        {
+          $comparison: "NA",
+          ami: "40",
+        },
+        {
+          $comparison: "=",
+          name: "Coliseum",
+        },
+      ]
+
+      addFilters(filters, filterTypeToFieldMap, mockQueryBuilder)
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining("ami_percentage"),
+        {
+          amiPercentage_unitsSummary: 40,
+          amiPercentage_listings: 40,
+        }
+      )
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(expect.stringContaining("="), {
+        name_1: expect.stringContaining("Coliseum"),
+      })
+    })
   })
 })

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -29,7 +29,6 @@ export function addFilters<FilterParams extends Array<any>, FilterFieldMap>(
   filterTypeToFieldMap: FilterFieldMap,
   qb: WhereExpression
 ): void {
-  // todo avaleske this is the wrong index to use for the where param name
   for (const [index, filter] of filters.entries()) {
     const comparison = filter["$comparison"]
     const includeNulls = filter["$include_nulls"]

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -29,6 +29,7 @@ export function addFilters<FilterParams extends Array<any>, FilterFieldMap>(
   filterTypeToFieldMap: FilterFieldMap,
   qb: WhereExpression
 ): void {
+  // todo avaleske this is the wrong index to use for the where param name
   for (const [index, filter] of filters.entries()) {
     const comparison = filter["$comparison"]
     const includeNulls = filter["$include_nulls"]
@@ -51,13 +52,13 @@ export function addFilters<FilterParams extends Array<any>, FilterFieldMap>(
       switch (filterKey) {
         case ListingFilterKeys.seniorHousing:
           addSeniorHousingQuery(qb, filterValue, includeNulls)
-          return
+          continue
         case ListingFilterKeys.availability:
           addAvailabilityQuery(qb, filterValue as AvailabilityFilterEnum, includeNulls)
-          return
+          continue
         case ListingFilterKeys.ami:
           addAmiPercentageFilter(qb, parseInt(filterValue), includeNulls)
-          return
+          continue
       }
 
       const whereParameterName = `${filterKey}_${index}`


### PR DESCRIPTION
## Issue 574

- Closes #574
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
We were `return`ing from `addFilters()` after adding a custom filter, instead of `continue`ing the for loop with the next filter.

Relatedly, if a unit has no availability, we show "waitlist" in the summary. That is misleading, since a unit could show "waitlist" when the building waitlist is not open. That is done here:
https://github.com/CityOfDetroit/bloom/blob/6e91c9231bad636bfbf690845cb01dd4d0bdf210/ui-components/src/helpers/tableSummaries.tsx#L51-L61
cc @willrlin 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?
Try adding a custom filter, and see that it only further refines the results, instead of ignoring other filters.

- [ ] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
