### PR TITLE
Validate the `listing.managementWebsite` url in the import script

### DIFF
--- a/backend/core/scripts/import-helpers.ts
+++ b/backend/core/scripts/import-helpers.ts
@@ -159,6 +159,16 @@ export async function importListing(
   const relationsKeys = []
   listing = reformatListing(listing, relationsKeys)
 
+  // If a managementWebsite is provided, make sure it is a well-formed URL.
+  if (listing.managementWebsite) {
+    if (!listing.managementWebsite.startsWith("http")) {
+      listing.managementWebsite = "http://" + listing.managementWebsite
+    }
+
+    // This next line will throw an error if managementWebsite is a malformed URL.
+    new URL(listing.managementWebsite)
+  }
+
   // Upload new entities.
   listing = await uploadEntity("preferences", preferencesService, listing)
   listing = await uploadEntity("applicationMethods", applicationMethodsService, listing)

--- a/backend/core/scripts/import-helpers.ts
+++ b/backend/core/scripts/import-helpers.ts
@@ -166,7 +166,16 @@ export async function importListing(
     }
 
     // This next line will throw an error if managementWebsite is a malformed URL.
-    new URL(listing.managementWebsite)
+    try {
+      new URL(listing.managementWebsite)
+    } catch (e) {
+      console.log(
+        `Error: ${listing.name} has a malformed managementWebsite (${listing.managementWebsite});` +
+          ` this website will be discarded and the listing will be uploaded without it.`
+      )
+      console.log(e)
+      listing.managementWebsite = null
+    }
   }
 
   // Upload new entities.


### PR DESCRIPTION
## Issue

- Closes #400

## Description

This change makes it so that (if a listing specifies a `managementWebsite`) that listing will only be successfully uploaded if `managementWebsite` is a well-formed URL. (Otherwise we'll note the error and move on to the next listing.)

For what qualifies as a "well-formed URL", I defer to whatever checks happen in the [Javascript URL constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL). One thing to note: "www.google.com" is considered invalid, whereas "http://www.google.com" is considered valid; as a result, the validation added in this change checks for a missing "http://" and adds it if needed. (We are already checking for the missing "http://" in the frontend, https://github.com/CityOfDetroit/bloom/blob/7ec1509e59ff6ffa27213fb4806cb0ec4607ace3/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx#L24-L27, but Exygy wisely suggested we instead check on import.)

Last note: all `managementWebsite`s in the HRD CSV file are well-formed (or only needed the addition of "http://").

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Run the import-from-JSON script, and try adding different `managementWebsite` values to `minimal_listings.json`. Script command:

`yarn ts-node scripts/import-listing-from-json-file.ts http://localhost:3100 admin@example.com:abcdef scripts/minimal-listing.json`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
