### PR TITLE
Fix filter reset

### DIFF
--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -120,8 +120,8 @@ const ListingsPage = () => {
   ]
   const adaCompliantOptions: SelectOption[] = [
     EMPTY_OPTION,
-    { value: "n", label: t("t.no") },
     { value: "y", label: t("t.yes") },
+    { value: "n", label: t("t.no") },
   ]
 
   const availabilityOptions: SelectOption[] = [
@@ -161,12 +161,11 @@ const ListingsPage = () => {
 
   let numberOfFilters = 0
   if (filterState) {
-    numberOfFilters = Object.keys(filterState).filter((p) => p !== "$comparison").length
+    numberOfFilters = Object.keys(filterState).filter(
+      (p) => p !== "$comparison" && p !== "includeNulls"
+    ).length
     // We want to consider rent as a single filter, so if both min and max are defined, reduce the count.
     if (filterState.minRent !== undefined && filterState.maxRent != undefined) {
-      numberOfFilters -= 1
-    }
-    if (filterState.includeNulls) {
       numberOfFilters -= 1
     }
   }
@@ -267,7 +266,6 @@ const ListingsPage = () => {
               register={register}
               controlClassName="control"
               options={adaCompliantOptions}
-              defaultValue={filterState?.seniorHousing?.toString()}
             />
             <Select
               id="seniorHousing"
@@ -276,6 +274,7 @@ const ListingsPage = () => {
               register={register}
               controlClassName="control"
               options={seniorHousingOptions}
+              defaultValue={filterState?.seniorHousing?.toString()}
             />
             <Field
               id="includeNulls"
@@ -316,7 +315,7 @@ const ListingsPage = () => {
             size={AppearanceSizeType.small}
             styleType={AppearanceStyleType.secondary}
             // "Submit" the form with no params to trigger a reset.
-            onClick={() => onSubmit(null)}
+            onClick={() => onSubmit({})}
             icon="close"
             iconPlacement="left"
           >

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -53,7 +53,7 @@ export interface ListingFilterState {
   [FrontendListingFilterStateKeys.minRent]?: string | number
   [FrontendListingFilterStateKeys.maxRent]?: string | number
   [FrontendListingFilterStateKeys.seniorHousing]?: string | boolean
-  [FrontendListingFilterStateKeys.includeNulls]?: string | boolean
+  [FrontendListingFilterStateKeys.includeNulls]?: boolean
 }
 
 export function encodeToBackendFilterArray(filterState: ListingFilterState) {

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -92,7 +92,7 @@ export function decodeFiltersFromFrontendUrl(
   const filterState: ListingFilterState = {}
   let foundFilterKey = false
   for (const queryKey in query) {
-    if (queryKey in FrontendListingFilterStateKeys) {
+    if (queryKey in FrontendListingFilterStateKeys && query[queryKey]) {
       filterState[queryKey] = query[queryKey]
       foundFilterKey = true
     }

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -92,7 +92,7 @@ export function decodeFiltersFromFrontendUrl(
   const filterState: ListingFilterState = {}
   let foundFilterKey = false
   for (const queryKey in query) {
-    if (queryKey in FrontendListingFilterStateKeys && query[queryKey]) {
+    if (queryKey in FrontendListingFilterStateKeys && query[queryKey] !== "") {
       filterState[queryKey] = query[queryKey]
       foundFilterKey = true
     }


### PR DESCRIPTION
## Issue

- Closes #637

## Description

A few small fixes I noticed from the deployed site:
- Filter reset button doesn't work - pass in the empty object instead of null.
- includeNulls was able to be set as an empty string in the URL, which would result in it existing as an array in the filter params - check that the value of the filter is not falsey before encoding it into the ListingFilterState object.
- Default value on the Senior Housing filter was not getting set - the default was being set to the ADA filter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested/Reviewed?

View the site and play with the filter modal.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
