### PR TITLE
Revert senior housing filters to exclude includeNulls

### DIFF
--- a/backend/core/src/shared/filter/custom_filters.ts
+++ b/backend/core/src/shared/filter/custom_filters.ts
@@ -5,25 +5,16 @@ import {
 } from "../../listings/types/listing-filter-keys-enum"
 import { filterTypeToFieldMap } from "../../listings/dto/listing.dto"
 
-export function addSeniorHousingQuery(
-  qb: WhereExpression,
-  filterValue: string,
-  includeNulls?: boolean
-) {
+export function addSeniorHousingQuery(qb: WhereExpression, filterValue: string) {
   const whereParameterName = ListingFilterKeys.seniorHousing
   const seniorHousingCommunityType = "senior62"
   const reservedCommunityTypeColumnName = `LOWER(CAST(${
     filterTypeToFieldMap[ListingFilterKeys.seniorHousing]
   } as text))`
   if (filterValue == "true") {
-    qb.andWhere(
-      `(${reservedCommunityTypeColumnName} = LOWER(:${whereParameterName})  ${
-        includeNulls ? `OR ${reservedCommunityTypeColumnName} IS NULL` : ""
-      })`,
-      {
-        [whereParameterName]: seniorHousingCommunityType,
-      }
-    )
+    qb.andWhere(`${reservedCommunityTypeColumnName} = LOWER(:${whereParameterName})`, {
+      [whereParameterName]: seniorHousingCommunityType,
+    })
   } else if (filterValue == "false") {
     qb.andWhere(
       `(${reservedCommunityTypeColumnName} IS NULL OR ${reservedCommunityTypeColumnName} <> LOWER(:${whereParameterName}))`,

--- a/backend/core/src/shared/filter/index.ts
+++ b/backend/core/src/shared/filter/index.ts
@@ -50,7 +50,7 @@ export function addFilters<FilterParams extends Array<any>, FilterFieldMap>(
       // Handle custom filters here, before dropping into generic filter handler
       switch (filterKey) {
         case ListingFilterKeys.seniorHousing:
-          addSeniorHousingQuery(qb, filterValue, includeNulls)
+          addSeniorHousingQuery(qb, filterValue)
           continue
         case ListingFilterKeys.availability:
           addAvailabilityQuery(qb, filterValue as AvailabilityFilterEnum, includeNulls)


### PR DESCRIPTION
## Issue

- Closes # (issue)
- Addresses # Filtering unknowns with Senior Housing

## Description

Including unknown information doesn't make sense for the senior housing filter, so this change reverts the filter back to the prior state before includeNulls was introduced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Filter by senior housing.

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
