### PR TITLE
Indicate which page of listings we're on

### DIFF
--- a/ui-components/src/global/vendor/AgPagination.tsx
+++ b/ui-components/src/global/vendor/AgPagination.tsx
@@ -7,7 +7,7 @@ type AgPaginationProps = {
   currentPage: number
   itemsPerPage: number
   sticky?: boolean
-  quantityLabel?: string
+  quantityLabel: string
   setCurrentPage: React.Dispatch<React.SetStateAction<number>> | ((page: number) => void)
   setItemsPerPage?: React.Dispatch<React.SetStateAction<number>>
   onPageChange?: (page: number) => void
@@ -59,10 +59,14 @@ const AgPagination = ({
 
       <div className="data-pager__control-group ml-0 md:ml-auto w-full md:w-auto md:flex md:items-center">
         <div className="data-pager__control">
-          <span className="field-label" id="lbTotalPages">
-            {totalItems}
+          <span className="field-label">
+            <strong>
+              Page {currentPage} of {totalPages}
+            </strong>
           </span>
-          {quantityLabel && <span className="field-label">{quantityLabel}</span>}
+          <span className="field-label">
+            ({totalItems} {quantityLabel})
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Issue

- Addresses #313

## Description

This change adds "Page X of Y" at the bottom of the listings list page.

Desktop:
![image](https://user-images.githubusercontent.com/8754454/134969869-9c294313-b496-4e07-9c16-ce8cc73c3d4a.png)

Mobile:
![image](https://user-images.githubusercontent.com/8754454/134969907-11216297-4a97-4aa1-8a1c-b9d60c3ada4d.png)

It also:
- Makes the `quantityLabel` (e.g. "Total Listings") a required field because simply putting "75" (the number of listings) with no unit would be weird.
- Makes the "Page X of Y" text bold, and leaves the "total listings" text as-is, to more easily visually distinguish them

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

- [X] Desktop View
- [X] Mobile View

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
