### PR TITLE
Fix pagination bar when there are zero items

### DIFF
--- a/ui-components/src/global/vendor/AgPagination.tsx
+++ b/ui-components/src/global/vendor/AgPagination.tsx
@@ -72,11 +72,13 @@ const AgPagination = ({
 
         <div className="data-pager__control-group ml-0 md:ml-auto w-full md:w-auto md:flex md:items-center">
           <div className="data-pager__control">
-            <span className="field-label">
-              <strong>
-                Page {currentPage} of {totalPages}
-              </strong>
-            </span>
+            {totalItems > 0 && (
+              <span className="field-label">
+                <strong>
+                  Page {currentPage} of {totalPages}
+                </strong>
+              </span>
+            )}
             <span className="field-label">
               ({totalItems} {quantityLabel})
             </span>


### PR DESCRIPTION
## Issue

- Addresses #313

## Description

Before this change, when there are zero items to display, the pagination bar would say "Page 1 of 0":

![image](https://user-images.githubusercontent.com/8754454/135896988-5032a365-dbb5-4276-9fae-4ad512ad48b7.png)

This change makes it so the pagination bar detects when there are no items to display, and removes the "Page X of Y" altogether:

![image](https://user-images.githubusercontent.com/8754454/135897113-5900d212-6ffd-4bab-8e4c-82a2256cc2f1.png)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I checked the listings pagination on both the public and partners sites, in desktop and mobile views.

- [X] Desktop View
- [X] Mobile View

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
