### PR TITLE
Bring our listing import scripts more in sync with Exygy's

### DIFF
--- a/backend/core/scripts/detroit-helpers.ts
+++ b/backend/core/scripts/detroit-helpers.ts
@@ -1,7 +1,3 @@
-import * as client from "../types/src/backend-swagger"
-import axios from "axios"
-import { serviceOptions } from "../types/src/backend-swagger"
-import { CountyCode } from "../src/shared/types/county-code"
 import { UnitStatus } from "../src/units/types/unit-status-enum"
 
 export function createUnitsArray(type: string, number: number) {
@@ -13,50 +9,4 @@ export function createUnitsArray(type: string, number: number) {
     })
   }
   return units
-}
-
-export async function getJurisdictions(
-  apiUrl: string,
-  email: string,
-  password: string
-): Promise<client.Jurisdiction[]> {
-  serviceOptions.axios = axios.create({
-    baseURL: apiUrl,
-    timeout: 10000,
-  })
-  // Log in to retrieve an access token.
-  const authService = new client.AuthService()
-  const { accessToken } = await authService.login({
-    body: {
-      email: email,
-      password: password,
-    },
-  })
-
-  // Update the axios config so future requests include the access token in the header.
-  serviceOptions.axios = axios.create({
-    baseURL: apiUrl,
-    timeout: 10000,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
-
-  const jurisdictionsService = new client.JurisdictionsService()
-
-  return jurisdictionsService.list()
-}
-
-export async function getDetroitJurisdiction(
-  apiUrl: string,
-  email: string,
-  password: string
-): Promise<client.Jurisdiction> {
-  try {
-    const jurisdictions = await getJurisdictions(apiUrl, email, password)
-    return jurisdictions.find((jurisdiction) => jurisdiction.name === CountyCode.detroit)
-  } catch (e) {
-    console.log(e)
-    return undefined
-  }
 }

--- a/backend/core/scripts/import-listing-from-json-file.ts
+++ b/backend/core/scripts/import-listing-from-json-file.ts
@@ -1,6 +1,6 @@
 import { importListing, ListingImport } from "./import-helpers"
 import fs from "fs"
-import { getDetroitJurisdiction } from "./detroit-helpers"
+import { Listing } from "../types/src/backend-swagger"
 
 // Example usage (from within /backend/core):
 // $ yarn ts-node scripts/import-listing-from-json-file.ts http://localhost:3100 admin@example.com:abcdef scripts/minimal-listing.json
@@ -16,12 +16,9 @@ async function main() {
   const [apiUrl, userAndPassword, listingFilePath] = process.argv.slice(2)
   const [email, password] = userAndPassword.split(":")
 
-  const jurisdiction = await getDetroitJurisdiction(apiUrl, email, password)
-
   const listing: ListingImport = JSON.parse(fs.readFileSync(listingFilePath, "utf-8"))
-  listing.jurisdiction = jurisdiction
 
-  let newListing
+  let newListing: Listing
   try {
     newListing = await importListing(apiUrl, email, password, listing)
   } catch (e) {

--- a/backend/core/scripts/import-listings-from-csv.ts
+++ b/backend/core/scripts/import-listings-from-csv.ts
@@ -1,7 +1,6 @@
 import csv from "csv-parser"
 import fs from "fs"
 import { importListing, ListingImport, UnitsSummaryImport } from "./import-helpers"
-import { getDetroitJurisdiction } from "./detroit-helpers"
 import { AddressCreate, CSVFormattingType, ListingStatus } from "../types/src/backend-swagger"
 
 // This script reads in listing data from a CSV file and sends requests to the backend to create
@@ -72,8 +71,6 @@ async function main() {
   await promise
 
   console.log(`CSV file successfully read in; ${rawListingFields.length} listings to upload`)
-
-  const jurisdiction = await getDetroitJurisdiction(importApiUrl, email, password)
 
   const uploadFailureMessages = []
   let numListingsSuccessfullyUploaded = 0
@@ -165,7 +162,7 @@ async function main() {
       amiPercentageMax: amiPercentageMax,
       status: ListingStatus.active,
       unitsSummary: unitsSummaries,
-      jurisdiction: jurisdiction,
+      jurisdictionName: "Detroit",
       reservedCommunityTypeName: reservedCommunityTypeName,
 
       // The following fields are only set because they are required

--- a/backend/core/scripts/import-listings-from-detroit-arcgis.ts
+++ b/backend/core/scripts/import-listings-from-detroit-arcgis.ts
@@ -1,5 +1,5 @@
 import { importListing, ListingImport, UnitImport } from "./import-helpers"
-import { createUnitsArray, getDetroitJurisdiction } from "./detroit-helpers"
+import { createUnitsArray } from "./detroit-helpers"
 import axios from "axios"
 import { AddressCreate, ListingStatus, CSVFormattingType } from "../types/src/backend-swagger"
 
@@ -20,8 +20,6 @@ async function main() {
   const response = await axios.get(arcGisUrl, {
     params: { where: "1=1", f: "pjson", outFields: "*" },
   })
-
-  const jurisdiction = await getDetroitJurisdiction(importApiUrl, email, password)
 
   const numListings: number = response.data.features.length
   for (let i = 0; i < numListings; i++) {
@@ -83,7 +81,7 @@ async function main() {
       leasingAgentAddress: leasingAgentAddress,
       phoneNumber: listingAttributes.Property_Phone,
       status: ListingStatus.active,
-      jurisdiction: jurisdiction,
+      jurisdictionName: "Detroit",
 
       // The following fields are only set because they are required
       CSVFormattingType: CSVFormattingType.basic,

--- a/backend/core/scripts/minimal-listing.json
+++ b/backend/core/scripts/minimal-listing.json
@@ -14,10 +14,7 @@
   },
   "units": [
     {
-      "unitType": {
-        "name": "oneBdrm",
-        "numBedrooms": 1
-      },
+      "unitType": "oneBdrm",
       "status": "available"
     }
   ],
@@ -25,7 +22,5 @@
   "applicationMethods": [],
   "events": [],
   "displayWaitlistSize": false,
-  "jurisdiction": {
-    "id": "651b272c-aeaa-4808-a581-1c761e52cb53"
-  }
+  "jurisdictionName": "Detroit"
 }


### PR DESCRIPTION
## Issue

- Closes #384

## Description

This change removes jurisdiction-lookup logic from `detroit-helpers.ts` and instead uses the jurisdiction-lookup logic that already exists in Exygy's version of `import-helpers.ts`. This (a) brings our import script in sync with Exygy's and (b) allows us to get rid of some verbose code.

There are also a few other one-line changes to bring our listing import script up to date with Exygy's.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [X] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I ran each of the three import scripts and verified that they each worked successfully (esp wrt getting the correct jurisdiction).

To verify that this brings us in sync with Exygy, I used a diff tool to check for diffs between their and our versions of the files touched in this PR. (The only remaining diffs are "real" diffs: e.g. "Detroit" instead of "Alameda" in `minimal-listing.json`.)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
