### PR TITLE
Add missing routePrefix to locales.

### DIFF
--- a/ui-components/__tests__/navigation/LanguageNav.test.tsx
+++ b/ui-components/__tests__/navigation/LanguageNav.test.tsx
@@ -1,29 +1,54 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react"
 import { LanguageNav } from "../../src/navigation/LanguageNav"
+import { t } from "../../src/helpers/translator"
+import { mocked } from "ts-jest/utils"
+
+jest.mock("../../src/helpers/translator");
+const mockedT = mocked(t, true)
 
 afterEach(cleanup)
 
 describe("<LanguageNav>", () => {
   it("renders without error", () => {
-    const props = {
-      language: {
-        list: [
-          {
-            prefix: "",
-            label: "English",
-          },
-          {
-            prefix: "es",
-            label: "Spanish",
-          },
-        ],
-        codes: ["en", "es"],
-      },
+    const language = {
+      list: [
+        {
+          prefix: "",
+          label: "English",
+        },
+        {
+          prefix: "es",
+          label: "Spanish",
+        },
+      ],
+      codes: ["en", "es"],
     }
 
-    const { getByText } = render(<LanguageNav language={props.language} />)
+    const { getByText } = render(<LanguageNav language={language} />)
     expect(getByText("English")).toBeTruthy()
     expect(getByText("Spanish")).toBeTruthy()
+  })
+
+  it("sets is-active on correct item", () => {
+    const language = {
+      list: [
+        {
+          prefix: "",
+          label: "English",
+        },
+        {
+          prefix: "es",
+          label: "Spanish",
+        },
+      ],
+      codes: ["en", "es"],
+    }
+
+    mockedT.mockReturnValue("es")
+
+    const { getByText } = render(<LanguageNav language={language} />)
+    expect(getByText("English").className).not.toContain("is-active")
+    expect(getByText("Spanish").className).toContain("is-active")
   })
 })

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "routePrefix": "ar"
+    },
     "account": {
         "accountSettings": "إعدادت الحساب",
         "errorFetchingApplications": "خطأ في جلب التطبيقات",
@@ -649,7 +652,6 @@
             "success": "لقد قمت بتسجيل الخروج بنجاح من حسابك."
         }
     },
-    "config": {},
     "errors": {
         "alert": {
             "timeoutPleaseTryAgain": "وجه الفتاة! يبدو أنه حدث خطأ ما. حاول مرة اخرى."

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "routePrefix": "bn"
+    },
     "account": {
         "accountSettings": "অ্যাকাউন্ট সেটিংস",
         "errorFetchingApplications": "অ্যাপ্লিকেশন আনতে ত্রুটি",
@@ -649,7 +652,6 @@
             "success": "আপনি আপনার অ্যাকাউন্ট থেকে সফলভাবে লগ আউট করেছেন।"
         }
     },
-    "config": {},
     "errors": {
         "alert": {
             "timeoutPleaseTryAgain": "উফ! মনে হচ্ছে কিছু ভুল হয়েছে। অনুগ্রহপূর্বক আবার চেষ্টা করুন."

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "routePrefix": "es"
+    },
     "account": {
         "accountSettings": "Configuraciones de la cuenta",
         "errorFetchingApplications": "Error al recuperar aplicaciones",
@@ -524,7 +527,6 @@
             "success": "Ha cerrado la sesión con éxito de su cuenta."
         }
     },
-    "config": {},
     "errors": {
         "alert": {
             "timeoutPleaseTryAgain": "¡UPS! Parece que algo salió mal. Inténtalo de nuevo."


### PR DESCRIPTION
## Issue

- Closes #618
- Addresses #618
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The routePrefix config controls when to apply the is-active class to LanguageNav components. This also adds a basic unit test to verify that is-active is set on the appropriate list item.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd ui-components && yarn test --testPathPattern LanguageNav`

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
