### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,6 @@ services:
       - postgres
   redis:
     container_name: redis
-    restart: always
     image: redis:latest
     ports:
       - "6379:6379"
@@ -95,7 +94,6 @@ services:
       - backend
   postgres:
     container_name: postgres
-    restart: always
     image: postgres:13
     environment:
       POSTGRES_USER: "postgres"


### PR DESCRIPTION
Don't always restart the containers, this makes it really difficult to remove the installation entirely. I could not figure out why postgres kept restarting on my machine even after removing the package; it was due to docker restarting it on boot.