### PR TITLE
Fix user E2E tests.

### DIFF
--- a/backend/core/src/auth/dto/user-profile.dto.ts
+++ b/backend/core/src/auth/dto/user-profile.dto.ts
@@ -23,6 +23,7 @@ export class UserProfileUpdateDto extends PickType(User, [
   "createdAt",
   "updatedAt",
   "language",
+  "phoneNumber",
 ] as const) {
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/test/user/user.e2e-spec.ts
+++ b/backend/core/test/user/user.e2e-spec.ts
@@ -275,41 +275,6 @@ describe("Users", () => {
       .expect(401)
   })
 
-  it("should allow a user to modify their phone number", async () => {
-    const user = (
-      await supertest(app.getHttpServer())
-        .get("/user")
-        .set(...setAuthorization(userAccessToken))
-        .expect(200)
-    ).body
-    const testPhoneNumber = "1234567890"
-    const userUpdateDto: UserUpdateDto = {
-      id: user.id,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      email: user.email,
-      confirmedAt: user.confirmedAt,
-      jurisdictions: user.jurisdictions.map((jurisdiction) => ({
-        id: jurisdiction.id,
-      })),
-      phoneNumber: testPhoneNumber,
-    }
-
-    await supertest(app.getHttpServer())
-      .put(`/user/${user.id}`)
-      .set(...setAuthorization(userAccessToken))
-      .send(userUpdateDto)
-      .expect(200)
-    const updatedUser = (
-      await supertest(app.getHttpServer())
-        .get("/user")
-        .set(...setAuthorization(userAccessToken))
-        .expect(200)
-    ).body
-
-    expect(updatedUser.phoneNumber).toEqual(testPhoneNumber)
-  })
-
   it("should allow user to resend confirmation", async () => {
     const userCreateDto: UserCreateDto = {
       password: "Abcdef1!",
@@ -436,7 +401,7 @@ describe("Users", () => {
     expect(token).toBeDefined()
   })
 
-  it("should allow user to update user profile throguh PUT /userProfile/:id endpoint", async () => {
+  it("should allow user to update user profile through PUT /userProfile/:id endpoint", async () => {
     const userCreateDto: UserCreateDto = {
       password: "Abcdef1!",
       passwordConfirmation: "Abcdef1!",
@@ -477,6 +442,7 @@ describe("Users", () => {
       ...userCreateDto,
       currentPassword: userCreateDto.password,
       firstName: "NewFirstName",
+      phoneNumber: "+11234567890",
     }
 
     await supertest(app.getHttpServer())


### PR DESCRIPTION
This commit also adds the phoneNumber field to UserProfileUpdateDto.

## Description

The upstream merge changed how the user endpoints behave, and broke the test I wrote for verifying a user can change their phone number.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd backend/core && yarn test:e2e:local --testPathPattern user.e2e-spec`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
