### PR TITLE
feat: add user preferences table

### DIFF
--- a/backend/core/src/auth/dto/user-basic.dto.ts
+++ b/backend/core/src/auth/dto/user-basic.dto.ts
@@ -6,6 +6,7 @@ import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enu
 import { UserRolesDto } from "./user-roles.dto"
 import { JurisdictionDto } from "../../jurisdictions/dto/jurisdiction.dto"
 import { IdDto } from "../../shared/dto/id.dto"
+import { UserPreferencesDto } from "../../../src/user-preferences/dto/user-preferences.dto"
 
 export class UserBasicDto extends OmitType(User, [
   "leasingAgentInListings",
@@ -14,6 +15,7 @@ export class UserBasicDto extends OmitType(User, [
   "resetToken",
   "roles",
   "jurisdictions",
+  "preferences",
 ] as const) {
   @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
@@ -33,4 +35,10 @@ export class UserBasicDto extends OmitType(User, [
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => IdDto)
   leasingAgentInListings?: IdDto[] | null
+
+  @Expose()
+  @IsOptional()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => UserPreferencesDto)
+  preferences?: UserPreferencesDto | null
 }

--- a/backend/core/src/auth/dto/user-profile.dto.ts
+++ b/backend/core/src/auth/dto/user-profile.dto.ts
@@ -16,6 +16,7 @@ import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enu
 import { passwordRegex } from "../../shared/password-regex"
 import { IdDto } from "../../shared/dto/id.dto"
 import { EnforceLowerCase } from "../../shared/decorators/enforceLowerCase.decorator"
+import { UserPreferencesDto } from "../../../src/user-preferences/dto/user-preferences.dto"
 
 export class UserProfileUpdateDto extends PickType(User, [
   "id",
@@ -59,4 +60,9 @@ export class UserProfileUpdateDto extends PickType(User, [
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
   appUrl?: string | null
+
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => UserPreferencesDto)
+  preferences?: UserPreferencesDto
 }

--- a/backend/core/src/auth/dto/user.dto.ts
+++ b/backend/core/src/auth/dto/user.dto.ts
@@ -6,6 +6,7 @@ import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enu
 import { IdNameDto } from "../../shared/dto/idName.dto"
 import { UserRolesDto } from "./user-roles.dto"
 import { JurisdictionDto } from "../../jurisdictions/dto/jurisdiction.dto"
+import { UserPreferencesDto } from "../../../src/user-preferences/dto/user-preferences.dto"
 
 export class UserDto extends OmitType(User, [
   "leasingAgentInListings",
@@ -14,6 +15,7 @@ export class UserDto extends OmitType(User, [
   "confirmationToken",
   "roles",
   "jurisdictions",
+  "preferences",
 ] as const) {
   @Expose()
   @IsOptional()
@@ -33,4 +35,9 @@ export class UserDto extends OmitType(User, [
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => JurisdictionDto)
   jurisdictions: JurisdictionDto[]
+
+  @Expose()
+  @IsOptional()
+  @Type(() => UserPreferencesDto)
+  preferences?: UserPreferencesDto | null
 }

--- a/backend/core/src/auth/entities/user.entity.ts
+++ b/backend/core/src/auth/entities/user.entity.ts
@@ -28,6 +28,7 @@ import { Language } from "../../shared/types/language-enum"
 import { UserRoles } from "./user-roles.entity"
 import { Jurisdiction } from "../../jurisdictions/entities/jurisdiction.entity"
 import { EnforceLowerCase } from "../../shared/decorators/enforceLowerCase.decorator"
+import { UserPreferences } from "../../../src/user-preferences/entities/user-preferences.entity"
 
 @Entity({ name: "user_accounts" })
 @Unique(["email"])
@@ -124,4 +125,12 @@ export class User {
   @ManyToMany(() => Jurisdiction, { cascade: true, eager: true })
   @JoinTable()
   jurisdictions: Jurisdiction[]
+
+  @OneToOne(() => UserPreferences, (preferences) => preferences.user, {
+    eager: true,
+    cascade: true,
+    nullable: true,
+  })
+  @Expose()
+  preferences?: UserPreferences
 }

--- a/backend/core/src/auth/services/user.service.ts
+++ b/backend/core/src/auth/services/user.service.ts
@@ -39,6 +39,7 @@ import { userFilterTypeToFieldMap } from "../dto/user-filter-type-to-field-map"
 import { Application } from "../../applications/entities/application.entity"
 import { Listing } from "../../listings/entities/listing.entity"
 import { UserRoles } from "../entities/user-roles.entity"
+import { UserPreferences } from "../../../src/user-preferences/entities/user-preferences.entity"
 
 @Injectable({ scope: Scope.REQUEST })
 export class UserService {
@@ -276,6 +277,7 @@ export class UserService {
         jurisdictions: dto.jurisdictions
           ? (dto.jurisdictions as JurisdictionDto[])
           : [await this.jurisdictionResolverService.getJurisdiction()],
+        preferences: dto.preferences as UserPreferences,
       },
       authContext
     )
@@ -337,6 +339,7 @@ export class UserService {
         jurisdictions: dto.jurisdictions
           ? (dto.jurisdictions as JurisdictionDto[])
           : [await this.jurisdictionResolverService.getJurisdiction()],
+        preferences: dto.preferences as UserPreferences,
       },
       authContext
     )

--- a/backend/core/src/migration/1636490631999-add-user-preferences.ts
+++ b/backend/core/src/migration/1636490631999-add-user-preferences.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class addUserPreferences1636490631999 implements MigrationInterface {
+  name = "addUserPreferences1636490631999"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "user_preferences" ("send_email_notifications" boolean NOT NULL DEFAULT false, "send_sms_notifications" boolean NOT NULL DEFAULT false, "user_id" uuid NOT NULL, CONSTRAINT "REL_458057fa75b66e68a275647da2" UNIQUE ("user_id"), CONSTRAINT "PK_458057fa75b66e68a275647da2e" PRIMARY KEY ("user_id"))`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD CONSTRAINT "FK_458057fa75b66e68a275647da2e" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" DROP CONSTRAINT "FK_458057fa75b66e68a275647da2e"`
+    )
+    await queryRunner.query(`DROP TABLE "user_preferences"`)
+  }
+}

--- a/backend/core/src/user-preferences/dto/user-preferences.dto.ts
+++ b/backend/core/src/user-preferences/dto/user-preferences.dto.ts
@@ -1,0 +1,4 @@
+import { OmitType } from "@nestjs/swagger"
+import { UserPreferences } from "../entities/user-preferences.entity"
+
+export class UserPreferencesDto extends OmitType(UserPreferences, ["user"] as const) {}

--- a/backend/core/src/user-preferences/entities/user-preferences.entity.ts
+++ b/backend/core/src/user-preferences/entities/user-preferences.entity.ts
@@ -1,0 +1,20 @@
+import { User } from "../../../src/auth/entities/user.entity"
+import { Column, Entity, JoinColumn, OneToOne } from "typeorm"
+import { Expose } from "class-transformer"
+
+@Entity({ name: "user_preferences" })
+export class UserPreferences {
+  @OneToOne(() => User, (user) => user.preferences, {
+    primary: true,
+  })
+  @JoinColumn()
+  user: User
+
+  @Column("boolean", { default: false })
+  @Expose()
+  sendEmailNotifications?: boolean
+
+  @Column("boolean", { default: false })
+  @Expose()
+  sendSmsNotifications?: boolean
+}

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -3663,6 +3663,14 @@ export interface UserRoles {
   isPartner?: boolean
 }
 
+export interface UserPreferences {
+  /**  */
+  sendEmailNotifications?: boolean
+
+  /**  */
+  sendSmsNotifications?: boolean
+}
+
 export interface User {
   /**  */
   language?: Language
@@ -3675,6 +3683,9 @@ export interface User {
 
   /**  */
   jurisdictions: Jurisdiction[]
+
+  /**  */
+  preferences?: CombinedPreferencesTypes
 
   /**  */
   id: string
@@ -3746,6 +3757,9 @@ export interface UserCreate {
 
   /**  */
   phoneNumber?: string
+
+  /**  */
+  preferences?: CombinedPreferencesTypes
 }
 
 export interface UserBasic {
@@ -3760,6 +3774,9 @@ export interface UserBasic {
 
   /**  */
   leasingAgentInListings?: Id[]
+
+  /**  */
+  preferences?: CombinedPreferencesTypes
 
   /**  */
   id: string
@@ -3888,6 +3905,9 @@ export interface UserUpdate {
 
   /**  */
   phoneNumber?: string
+
+  /**  */
+  preferences?: CombinedPreferencesTypes
 }
 
 export interface UserFilterParams {
@@ -3950,6 +3970,9 @@ export interface UserInvite {
 
   /**  */
   phoneNumber?: string
+
+  /**  */
+  preferences?: CombinedPreferencesTypes
 }
 
 export interface UserProfileUpdate {
@@ -3970,6 +3993,9 @@ export interface UserProfileUpdate {
 
   /**  */
   appUrl?: string
+
+  /**  */
+  preferences?: UserPreferences
 
   /**  */
   id: string
@@ -6038,6 +6064,7 @@ export enum EnumApplicationsApiExtraModelOrder {
   "DESC" = "DESC",
 }
 export type CombinedRolesTypes = UserRolesCreate
+export type CombinedPreferencesTypes = UserPreferences
 export enum EnumUserFilterParamsComparison {
   "=" = "=",
   "<>" = "<>",


### PR DESCRIPTION
## Issue

- Closes #747

## Description

This adds a UserPreferences table, keyed on user id. Two notification preferences are initially added to the table.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

1. Go to swagger docs
2. Log in as test@example.com
3. GET `user/`
4. PUT `userProfile/`, setting `{"sendEmailNotifications": true}` for the `preferences` key
5. GET `user/` again, verify that `preferences is set

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
