### PR TITLE
Add aria labels to HorizontalScrollSection

### DIFF
--- a/sites/public/lib/HorizontalScrollSection.tsx
+++ b/sites/public/lib/HorizontalScrollSection.tsx
@@ -51,7 +51,9 @@ const HorizontalScrollSection = (props: HorizontalScrollSectionProps) => {
   return (
     <section className={props.className}>
       <div className={styles.title}>
-        {props.icon && <Icon size="xlarge" symbol={props.icon} className={styles.icon} />}
+        {props.icon && (
+          <Icon size="xlarge" symbol={props.icon} className={styles.icon} ariaHidden={true} />
+        )}
         <h2 className={`${styles.title__text} ${props.icon ? styles["icon-space"] : ""}`}>
           {props.title}
         </h2>
@@ -60,6 +62,7 @@ const HorizontalScrollSection = (props: HorizontalScrollSectionProps) => {
           className={styles.title__button}
           onClick={leftButtonClick}
           disabled={!canScrollLeft}
+          ariaLabel="Scroll left"
         >
           <Icon size="medium" symbol="left" />
         </Button>
@@ -68,6 +71,7 @@ const HorizontalScrollSection = (props: HorizontalScrollSectionProps) => {
           className={styles.title__button}
           onClick={rightButtonClick}
           disabled={!canScrollRight}
+          ariaLabel="Scroll right"
         >
           <Icon size="medium" symbol="right" />
         </Button>

--- a/ui-components/src/actions/Button.tsx
+++ b/ui-components/src/actions/Button.tsx
@@ -19,6 +19,7 @@ export interface ButtonProps extends AppearanceProps {
   className?: string
   disabled?: boolean
   loading?: boolean
+  ariaLabel?: string
 }
 
 export const buttonClassesForProps = (props: Omit<ButtonProps, "onClick">) => {
@@ -72,6 +73,7 @@ const Button = (props: ButtonProps) => {
       className={buttonClasses.join(" ")}
       onClick={props.onClick}
       disabled={props.disabled || props.loading}
+      aria-label={props.ariaLabel}
     >
       {buttonInner(props)}
     </button>

--- a/ui-components/src/icons/Icon.tsx
+++ b/ui-components/src/icons/Icon.tsx
@@ -133,6 +133,7 @@ export interface IconProps {
   symbol: IconTypes
   className?: string
   fill?: string
+  ariaHidden?: boolean
 }
 
 const Icon = (props: IconProps) => {
@@ -144,7 +145,7 @@ const Icon = (props: IconProps) => {
   const SpecificIcon = IconMap[props.symbol]
 
   return (
-    <span className={wrapperClasses.join(" ")}>
+    <span className={wrapperClasses.join(" ")} aria-hidden={props.ariaHidden}>
       <SpecificIcon fill={props.fill ? props.fill : undefined} />
     </span>
   )


### PR DESCRIPTION
## Issue


## Description

Adds aria labels to the left and right scroll buttons and adds aria-hidden to the section icons since those are only visual decoration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Inspect html on homepage or use a screenreader to navigate

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
