### PR TITLE
Tweak header css at medium screen size

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -15,7 +15,7 @@
 
     .navbar {
       height: auto;
-      justify-content: center;
+      justify-content: flex-start;
       max-height: none;
       padding: 8px 0 16px;
 
@@ -23,14 +23,22 @@
         padding: 0;
       }
 
+      @screen xl {
+        justify-content: center;
+      }
+
       .navbar-menu {
         height: 80px;
         min-width: 112px;
 
         @screen md {
-          margin: 48px 0 32px;
+          margin: 40px 0 24px;
           position: absolute;
           right: 1rem;
+        }
+
+        @screen xl {
+          margin: 48px 0 32px;
         }
 
         .navbar-link {
@@ -60,6 +68,10 @@
 
       .navbar-logo {
         @screen md {
+          padding: 48px 0 32px 16px;
+        }
+
+        @screen xl {
           padding: 48px 0 32px;
         }
 
@@ -85,8 +97,12 @@
             text-transform: none;
 
             @screen md {
-              @apply text-2xl;
+              @apply text-lg;
               margin: 0;
+            }
+
+            @screen xl {
+              @apply text-2xl;
             }
           }
 
@@ -99,8 +115,11 @@
             @screen md {
               // Negative margin to center around the shield
               margin: -32px 0 0;
+              max-height: 6rem;
+            }
+
+            @screen xl {
               max-height: 7rem;
-              min-height: 6rem;
             }
           }
         }


### PR DESCRIPTION
## Description

Carves out a medium screen size that left aligns the title so that we can have more links on the right side without overlapping the logo. The xl screen size is unchanged. This unblocks adding more pages to the header.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?
View site at medium size (between 768px and 1280px)

### Before
![image](https://user-images.githubusercontent.com/371177/141387256-65b49ffb-b0f3-428d-b28c-36175ba75476.png)

### After
![image](https://user-images.githubusercontent.com/371177/141387279-6ee0df65-30a7-4bf8-a77f-7b4e486f1a77.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
