### PR TITLE
fix: filtering on bedroom count

### DIFF
--- a/backend/core/src/listings/dto/filter-type-to-field-map.ts
+++ b/backend/core/src/listings/dto/filter-type-to-field-map.ts
@@ -14,7 +14,7 @@ type keysWithMappedField = Exclude<
 export const filterTypeToFieldMap: Record<keysWithMappedField, string> = {
   status: "listings.status",
   name: "listings.name",
-  bedrooms: "unitTypeRef.num_bedrooms",
+  bedrooms: "summaryUnitType.num_bedrooms",
   zipcode: "buildingAddress.zipCode",
   leasingAgents: "leasingAgents.id",
   seniorHousing: "reservedCommunityType.name",

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -382,6 +382,62 @@ describe("Listings", () => {
     })
   })
 
+  describe("Unit size filtering", () => {
+    it("should return listings with >= 1 bedroom", async () => {
+      const params = {
+        view: "base",
+        limit: "all",
+        filter: [
+          {
+            $comparison: ">=",
+            bedrooms: "1",
+          },
+        ],
+      }
+      const res = await supertest(app.getHttpServer())
+        .get("/listings?" + qs.stringify(params))
+        .expect(200)
+
+      const listings: Listing[] = res.body.items
+      expect(listings.length).toBeGreaterThan(0)
+      // expect that all listings have at least one unit with >= 1 bedroom
+      expect(
+        listings.map((listing) => {
+          listing.unitsSummary.find((unit) => {
+            unit.unitType.numBedrooms >= 1
+          }) !== undefined
+        })
+      ).not.toContain(false)
+    })
+
+    it("should return listings with exactly 1 bedroom", async () => {
+      const params = {
+        view: "base",
+        limit: "all",
+        filter: [
+          {
+            $comparison: "=",
+            bedrooms: "1",
+          },
+        ],
+      }
+      const res = await supertest(app.getHttpServer())
+        .get("/listings?" + qs.stringify(params))
+        .expect(200)
+
+      const listings: Listing[] = res.body.items
+      expect(listings.length).toBeGreaterThan(0)
+      // expect that all listings have at least one unit with exactly 1 bedroom
+      expect(
+        listings.map((listing) => {
+          listing.unitsSummary.find((unit) => {
+            unit.unitType.numBedrooms == 1
+          }) !== undefined
+        })
+      ).not.toContain(false)
+    })
+  })
+
   it("defaults to sorting listings by applicationDueDate, then applicationOpenDate", async () => {
     const res = await supertest(app.getHttpServer()).get(`/listings?limit=all`).expect(200)
     const listings = res.body.items


### PR DESCRIPTION
## Issue

- Closes #759

## Description

The "bedrooms" filter type had been mis-mapped to a field after the most recent upstream merge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Navigate to listings and apply a bedroom filter. OR:

`cd backend/core && yarn test:e2e:local --testPathPattern listings.e2e-spec --testNamePattern "Unit size filtering"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
