### PR TITLE
feat: update unit size filter

### DIFF
--- a/backend/core/src/listings/dto/listing-filter-params.ts
+++ b/backend/core/src/listings/dto/listing-filter-params.ts
@@ -31,13 +31,13 @@ export class ListingFilterParams extends BaseFilter {
 
   @Expose()
   @ApiProperty({
-    type: Number,
-    example: "3",
+    type: String,
+    example: "2, 3",
     required: false,
   })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsNumberString({}, { groups: [ValidationsGroupsEnum.default] })
-  [ListingFilterKeys.bedrooms]?: number;
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  [ListingFilterKeys.bedrooms]?: string;
 
   @Expose()
   @ApiProperty({

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4064,7 +4064,7 @@ export interface ListingFilterParams {
   status?: EnumListingFilterParamsStatus
 
   /**  */
-  bedrooms?: number
+  bedrooms?: string
 
   /**  */
   zipcode?: string

--- a/sites/public/src/forms/filters/FilterForm.tsx
+++ b/sites/public/src/forms/filters/FilterForm.tsx
@@ -99,15 +99,59 @@ const FilterForm = (props: FilterFormProps) => {
           options={availabilityOptions}
           defaultValue={props.filterState?.availability}
         />
-        <Select
-          id="unitOptions"
-          name={FrontendListingFilterStateKeys.bedrooms}
-          label={t("listingFilters.bedrooms")}
-          register={register}
-          controlClassName="control"
-          options={preferredUnitOptions}
-          defaultValue={props.filterState?.bedrooms?.toString()}
-        />
+        <label className="field-label">{t("listingFilters.bedrooms")}</label>
+        <div className="flex flex-row bedroom-selector">
+          <Field
+            id="studio"
+            name={FrontendListingFilterStateKeys.studio}
+            type="checkbox"
+            label={t("listingFilters.bedroomsOptions.studioPlus")}
+            register={register}
+            inputProps={{
+              defaultChecked: Boolean(props.filterState?.studio),
+            }}
+          />
+          <Field
+            id="oneBdrm"
+            name={FrontendListingFilterStateKeys.oneBdrm}
+            type="checkbox"
+            label={t("listingFilters.bedroomsOptions.onePlus")}
+            register={register}
+            inputProps={{
+              defaultChecked: Boolean(props.filterState?.oneBdrm),
+            }}
+          />
+          <Field
+            id="twoBdrm"
+            name={FrontendListingFilterStateKeys.twoBdrm}
+            type="checkbox"
+            label={t("listingFilters.bedroomsOptions.twoPlus")}
+            register={register}
+            inputProps={{
+              defaultChecked: Boolean(props.filterState?.twoBdrm),
+            }}
+          />
+          <Field
+            id="threeBdrm"
+            name={FrontendListingFilterStateKeys.threeBdrm}
+            type="checkbox"
+            label={t("listingFilters.bedroomsOptions.threePlus")}
+            register={register}
+            inputProps={{
+              defaultChecked: Boolean(props.filterState?.threeBdrm),
+            }}
+          />
+          <Field
+            id="fourPlusBdrm"
+            name={FrontendListingFilterStateKeys.fourPlusBdrm}
+            type="checkbox"
+            label={t("listingFilters.bedroomsOptions.fourPlus")}
+            register={register}
+            inputProps={{
+              defaultChecked: Boolean(props.filterState?.fourPlusBdrm),
+            }}
+          />
+        </div>
         <Field
           id="zipCodeField"
           name={FrontendListingFilterStateKeys.zipcode}

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -261,3 +261,9 @@ a.button.is-primary:hover {
   text-align: center;
   padding-bottom: 40px;
 }
+
+.bedroom-selector > .field {
+  label {
+    margin-top: 10px;
+  }
+}

--- a/ui-components/__tests__/helpers/filters.test.ts
+++ b/ui-components/__tests__/helpers/filters.test.ts
@@ -29,17 +29,28 @@ describe("encode backend filter array", () => {
 
   it("should handle multiple filters", () => {
     const filter: ListingFilterState = {
-      bedrooms: "3",
+      threeBdrm: true,
       zipcode: "48226",
+    }
+    expect(encodeToBackendFilterArray(filter)).toContainEqual({
+      $comparison: EnumListingFilterParamsComparison["IN"],
+      bedrooms: "3",
+    })
+    expect(encodeToBackendFilterArray(filter)).toContainEqual({
+      $comparison: EnumListingFilterParamsComparison["IN"],
+      zipcode: "48226",
+    })
+  })
+
+  it("should handle multiple bedroom filters", () => {
+    const filter: ListingFilterState = {
+      twoBdrm: true,
+      threeBdrm: true,
     }
     expect(encodeToBackendFilterArray(filter)).toEqual([
       {
-        $comparison: EnumListingFilterParamsComparison[">="],
-        bedrooms: "3",
-      },
-      {
         $comparison: EnumListingFilterParamsComparison["IN"],
-        zipcode: "48226",
+        bedrooms: "2,3",
       },
     ])
   })
@@ -55,18 +66,18 @@ describe("encode filter state as frontend querystring", () => {
 
   it("should handle multiple filters", () => {
     const filter: ListingFilterState = {
-      bedrooms: "3",
+      threeBdrm: true,
       zipcode: "48226",
     }
-    expect(encodeToFrontendFilterString(filter)).toBe("&bedrooms=3&zipcode=48226")
+    expect(encodeToFrontendFilterString(filter)).toBe("&threeBdrm=true&zipcode=48226")
   })
 
   it("should exclude empty filters", () => {
     const filter: ListingFilterState = {
-      bedrooms: "3",
+      threeBdrm: true,
       zipcode: "",
     }
-    expect(encodeToFrontendFilterString(filter)).toBe("&bedrooms=3")
+    expect(encodeToFrontendFilterString(filter)).toBe("&threeBdrm=true")
   })
 })
 
@@ -80,12 +91,12 @@ describe("get filter state from parsed url", () => {
   })
 
   it("should handle multiple filters", () => {
-    const filterString = parse("localhost:3000/listings?page=1&bedrooms=3&zipcode=48226")
+    const filterString = parse("localhost:3000/listings?page=1&threeBdrm=true&zipcode=48226")
     const expected: ListingFilterState = {
-      bedrooms: "3",
+      threeBdrm: "true",
       zipcode: "48226",
     }
-    expect(decodeFiltersFromFrontendUrl(filterString)).toStrictEqual(expected)
+    expect(decodeFiltersFromFrontendUrl(filterString)).toEqual(expected)
   })
 
   it("should handle no filters", () => {

--- a/ui-components/src/locales/ar.json
+++ b/ui-components/src/locales/ar.json
@@ -1347,13 +1347,13 @@
         "modalTitle": "تصفية النتائج",
         "modalHeader": "استخدم هذه الخيارات لتحسين قائمة الخصائص الخاصة بك.",
         "neighborhood": "حي",
-        "bedrooms": "حجم الوحدة",
+        "bedrooms": "غرف نوم",
         "bedroomsOptions": {
-            "studioPlus": "0 أو أكثر من غرف النوم (استوديو)",
-            "onePlus": "غرفة نوم واحدة أو أكثر",
-            "twoPlus": "2 غرف نوم أو أكثر",
-            "threePlus": "3 غرف نوم أو أكثر",
-            "fourPlus": "4 غرف نوم أو أكثر"
+            "studioPlus": "0 (استوديو)",
+            "onePlus": "1",
+            "twoPlus": "2",
+            "threePlus": "3",
+            "fourPlus": "4 أو أكثر"
         },
         "zipCode": "الرمز البريدي",
         "zipCodeDescription": "أدخل الرمز البريدي",

--- a/ui-components/src/locales/bn.json
+++ b/ui-components/src/locales/bn.json
@@ -1347,13 +1347,13 @@
         "modalTitle": "ফিল্টার ফল",
         "modalHeader": "আপনার বৈশিষ্ট্যের তালিকা পরিমার্জন করতে এই বিকল্পগুলি ব্যবহার করুন।",
         "neighborhood": "প্রতিবেশ",
-        "bedrooms": "একক পরিমান",
+        "bedrooms": "বেডরুম",
         "bedroomsOptions": {
-            "studioPlus": "0 বা তার বেশি শয়নকক্ষ (স্টুডিও)",
-            "onePlus": "1 বা ততোধিক বেডরুম",
-            "twoPlus": "2 বা ততোধিক বেডরুম",
-            "threePlus": "3 বা ততোধিক বেডরুম",
-            "fourPlus": "4 বা ততোধিক বেডরুম"
+            "studioPlus": "0 (স্টুডিও)",
+            "onePlus": "1",
+            "twoPlus": "2",
+            "threePlus": "3",
+            "fourPlus": "4 বা তার বেশি"
         },
         "zipCode": "জিপ কোড",
         "zipCodeDescription": "জিপ কোড প্রবেশ",

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1222,13 +1222,13 @@
         "modalTitle": "Filtrar resultados",
         "modalHeader": "Utilice estas opciones para refinar su lista de propiedades.",
         "neighborhood": "Vecindario",
-        "bedrooms": "Tamaño de la unidad",
+        "bedrooms": "Dormitorios",
         "bedroomsOptions": {
-            "studioPlus": "0 o más habitaciones (estudio)",
-            "onePlus": "1 o más dormitorios",
-            "twoPlus": "2 o más recámaras",
-            "threePlus": "3 o más recámaras",
-            "fourPlus": "4 o más recámaras"
+            "studioPlus": "0 (Estudio)",
+            "onePlus": "1",
+            "twoPlus": "2",
+            "threePlus": "3",
+            "fourPlus": "4 o más"
         },
         "zipCode": "Código postal",
         "zipCodeDescription": "Introduzca código postal",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1398,13 +1398,13 @@
     "modalTitle": "Filter results",
     "modalHeader": "Use these options to refine your list of properties.",
     "neighborhood": "Neighborhood",
-    "bedrooms": "Unit size",
+    "bedrooms": "Bedrooms",
     "bedroomsOptions": {
-      "studioPlus": "0 or more bedrooms (Studio)",
-      "onePlus": "1 or more bedrooms",
-      "twoPlus": "2 or more bedrooms",
-      "threePlus": "3 or more bedrooms",
-      "fourPlus": "4 or more bedrooms"
+      "studioPlus": "0 (Studio)",
+      "onePlus": "1",
+      "twoPlus": "2",
+      "threePlus": "3",
+      "fourPlus": "4 or more"
     },
     "zipCode": "Zip code",
     "zipCodeDescription": "Enter zip code",


### PR DESCRIPTION
## Issue

- Closes #752

## Description

This switched the unit size filter from a selector, to a set of checkboxes. Supporting the backend query is achieved by switching the `bedrooms` filter parameter from a number to a string, and switching the comparison from `>=` to `IN`. The frontend coalesces all the checkboxes to construct the `bedrooms` backend filter value. E.g. if "0" and "3" are checked, then `bedrooms="0,3"` is sent to the backend.

Desktop:
![localhost_3000_listings_filtered_page=1 fourPlusBdrm=true](https://user-images.githubusercontent.com/66751489/141838379-a834ee15-12ef-4403-888c-dd7fc523ac25.png)

Mobile:
![localhost_3000_listings_filtered_page=1 fourPlusBdrm=true (1)](https://user-images.githubusercontent.com/66751489/141838401-c21ca65b-cc64-4d79-b360-b9e0b40e82f7.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Go to filter modal, check "0" and "3", verify that only listings containing 0 or 3 bedrooms are returned.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
