### PR TITLE
chore: create River Towers seed listing

### DIFF
--- a/backend/core/src/detroit-seed.ts
+++ b/backend/core/src/detroit-seed.ts
@@ -28,6 +28,7 @@ import { Listing10159Seed } from "./seeds/listings/listing-detroit-10159"
 import { Listing10168Seed } from "./seeds/listings/listing-detroit-10168"
 import { createJurisdictions } from "./seeds/jurisdictions"
 import { Jurisdiction } from "./jurisdictions/entities/jurisdiction.entity"
+import { Listing10202Seed } from "./seeds/listings/listing-detroit-10202"
 
 const argv = yargs.scriptName("seed").options({
   test: { type: "boolean", default: false },
@@ -47,6 +48,7 @@ const listingSeeds: any[] = [
   Listing10158Seed,
   Listing10159Seed,
   Listing10168Seed,
+  Listing10202Seed,
   ListingTreymoreSeed,
 ]
 

--- a/backend/core/src/seeder/seeder.module.ts
+++ b/backend/core/src/seeder/seeder.module.ts
@@ -38,6 +38,7 @@ import { Listing10158Seed } from "../seeds/listings/listing-detroit-10158"
 import { Listing10157Seed } from "../seeds/listings/listing-detroit-10157"
 import { Listing10147Seed } from "../seeds/listings/listing-detroit-10147"
 import { Listing10145Seed } from "../seeds/listings/listing-detroit-10145"
+import { Listing10202Seed } from "../seeds/listings/listing-detroit-10202"
 import { ListingTreymoreSeed } from "../seeds/listings/listing-detroit-treymore"
 import { UnitsSummary } from "../units-summary/entities/units-summary.entity"
 import { ListingDefaultMultipleAMI } from "../seeds/listings/listing-default-multiple-ami"
@@ -119,6 +120,7 @@ export class SeederModule {
         Listing10155Seed,
         Listing10159Seed,
         Listing10168Seed,
+        Listing10202Seed,
         ListingTreymoreSeed,
         ListingDefaultMultipleAMI,
         ListingDefaultMultipleAMIAndPercentages,

--- a/backend/core/src/seeds/listings/listing-detroit-10202.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10202.ts
@@ -1,0 +1,95 @@
+import { ListingSeedType, PropertySeedType } from "./listings"
+import { ListingStatus } from "../../listings/types/listing-status-enum"
+import { CountyCode } from "../../shared/types/county-code"
+import { CSVFormattingType } from "../../csv/types/csv-formatting-type-enum"
+import { ListingDefaultSeed } from "./listing-default-seed"
+import { BaseEntity, DeepPartial } from "typeorm"
+import { Listing } from "../../listings/entities/listing.entity"
+import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto"
+
+//
+const mcvProperty: PropertySeedType = {
+  buildingAddress: {
+    city: "Detroit",
+    state: "MI",
+    street: "7800 E Jefferson Ave",
+    zipCode: "48214",
+    latitude: 42.35046,
+    longitude: -82.99615,
+  },
+  buildingTotalUnits: 469,
+  neighborhood: "Gold Coast",
+}
+
+const mcvListing: ListingSeedType = {
+  amiPercentageMax: 60,
+  amiPercentageMin: null,
+  applicationDropOffAddress: null,
+  applicationMailingAddress: null,
+  countyCode: CountyCode.detroit,
+  CSVFormattingType: CSVFormattingType.basic,
+  disableUnitsAccordion: true,
+  displayWaitlistSize: false,
+  hrdId: "HRD10202",
+  leasingAgentName: "Janelle Henderson",
+  leasingAgentPhone: "313-824-2244",
+  managementCompany: "Associated Management Co",
+  managementWebsite: "associated-management.rentlinx.com/listings",
+  name: "River Towers",
+  status: ListingStatus.active,
+  image: undefined,
+  digitalApplication: undefined,
+  paperApplication: undefined,
+  referralOpportunity: undefined,
+  depositMin: undefined,
+  depositMax: undefined,
+  leasingAgentEmail: undefined,
+  rentalAssistance: undefined,
+  reviewOrderType: undefined,
+  isWaitlistOpen: undefined,
+}
+
+export class Listing10202Seed extends ListingDefaultSeed {
+  async seed() {
+    const unitTypeOneBdrm = await this.unitTypeRepository.findOneOrFail({ name: "oneBdrm" })
+    const unitTypeTwoBdrm = await this.unitTypeRepository.findOneOrFail({ name: "twoBdrm" })
+
+    const property = await this.propertyRepository.save({
+      ...mcvProperty,
+    })
+
+    const listingCreateDto: Omit<
+      DeepPartial<Listing>,
+      keyof BaseEntity | "urlSlug" | "showWaitlist"
+    > = {
+      ...mcvListing,
+      applicationMethods: [],
+      assets: [],
+      events: [],
+      property: property,
+      preferences: [],
+    }
+
+    const listing = await this.listingRepository.save(listingCreateDto)
+
+    const mcvUnitsSummaryToBeCreated: UnitsSummaryCreateDto[] = []
+
+    const oneBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeOneBdrm,
+      totalCount: 376,
+      listing: listing,
+    }
+    mcvUnitsSummaryToBeCreated.push(oneBdrmUnitsSummary)
+
+    const twoBdrmUnitsSummary: UnitsSummaryCreateDto = {
+      unitType: unitTypeTwoBdrm,
+      totalCount: 96,
+      listing: listing,
+    }
+    mcvUnitsSummaryToBeCreated.push(twoBdrmUnitsSummary)
+
+    await this.unitsSummaryRepository.save(mcvUnitsSummaryToBeCreated)
+
+    return listing
+  }
+}


### PR DESCRIPTION
## Issue

- Addresses #790

## Description

To test updating this listing from imported XML, we need an initial listing. Data is populated from the information in the HRD spreadsheet.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd backend/core && yarn db:reseed:detroit`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
