### PR TITLE
fix: pass waitlist + other info from backend

### DIFF
--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -94,7 +94,7 @@ class Listing extends BaseEntity {
   @Expose()
   @ApiPropertyOptional()
   get referralApplication(): ApplicationMethodDto | undefined {
-    return this.applicationMethods.find((method) => method.type === ApplicationMethodType.Referral)
+    return this.applicationMethods?.find((method) => method.type === ApplicationMethodType.Referral)
   }
 
   // booleans to make dealing with different application methods easier to parse

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -19,6 +19,7 @@ import { ListingUpdateDto } from "./dto/listing-update.dto"
 import { ListingFilterParams } from "./dto/listing-filter-params"
 import { ListingsQueryParams } from "./dto/listings-query-params"
 import { filterTypeToFieldMap } from "./dto/filter-type-to-field-map"
+import { mapTo } from "../../src/shared/mapTo"
 
 @Injectable()
 export class ListingsService {
@@ -121,6 +122,10 @@ export class ListingsService {
     if (params.jsonpath) {
       listings = jp.query(listings, params.jsonpath)
     }
+
+    // The result of the query above does not produce Listing instances, only objects. To ensure
+    // that `get` accessors work, we need to `mapTo` Listing instances.
+    listings = listings.map((l) => mapTo(Listing, l))
 
     // There is a bug in nestjs-typeorm-paginate's handling of complex, nested
     // queries (https://github.com/nestjsx/nestjs-typeorm-paginate/issues/6) so

--- a/backend/core/src/property/entities/property.entity.ts
+++ b/backend/core/src/property/entities/property.entity.ts
@@ -45,6 +45,7 @@ export class Property {
   updatedAt: Date
 
   @OneToMany(() => Unit, (unit) => unit.property, { eager: true, cascade: true })
+  @Expose()
   units: Unit[]
 
   @ManyToMany(() => PropertyGroup)

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -286,7 +286,7 @@ export const summarizeUnitsByTypeAndRent = (units: Units): UnitSummary[] => {
   const summaries: UnitSummary[] = []
   const unitMap: UnitMap = {}
 
-  units.forEach((unit) => {
+  units?.forEach((unit) => {
     const currentUnitType = unit.unitType
     const currentUnitRent = unit.monthlyRentAsPercentOfIncome
     const thisKey = currentUnitType?.name.concat(currentUnitRent)


### PR DESCRIPTION
## Issue

- Addresses #800

## Description

It seems the query builder logic doesn't return lists of the specified entity type, so it's necessary to map the returned query result to the entity type. Otherwise, `get` accessors don't work, since those are only defined on the entity type, and not on the generic objects that the query returns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Seed the db with Detroit listings, then find the "New Center Square" listing card. It should say "Open Waitlist" in the card:

![localhost_3000_listings (3)](https://user-images.githubusercontent.com/66751489/144296556-4709b8b5-5fdb-4d51-bf48-8fe358216d0f.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
