### PR TITLE
Chore/comma separate amenities

### DIFF
--- a/backend/core/src/seeds/listings/listing-detroit-10157.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10157.ts
@@ -21,7 +21,7 @@ const nccProperty: PropertySeedType = {
   buildingTotalUnits: 71,
   neighborhood: "New Center Commons",
   petPolicy: "No Pets Allowed",
-  unitAmenities: "Air Conditioning Dishwasher Garbage Disposal Range Refrigerator",
+  unitAmenities: "Air Conditioning, Dishwasher, Garbage Disposal, Range, Refrigerator",
   unitsAvailable: 5,
   yearBuilt: 1929,
 }

--- a/backend/core/src/seeds/listings/listing-detroit-10158.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-10158.ts
@@ -19,7 +19,7 @@ const ncpProperty: PropertySeedType = {
   },
   buildingTotalUnits: 76,
   neighborhood: "New Center Commons",
-  unitAmenities: "Air Conditioning(Wall unit), Garbage Disposal, Range, Refrigerator",
+  unitAmenities: "Air Conditioning (Wall unit), Garbage Disposal, Range, Refrigerator",
   yearBuilt: 1971,
 }
 

--- a/backend/core/src/seeds/listings/listing-detroit-treymore.ts
+++ b/backend/core/src/seeds/listings/listing-detroit-treymore.ts
@@ -9,7 +9,7 @@ import { UnitsSummaryCreateDto } from "../../units-summary/dto/units-summary.dto
 
 const treymoreProperty: PropertySeedType = {
   // See http://rentlinx.kmgprestige.com/457-Brainard-Street-Detroit-MI-48201
-  amenities: "Parking Elevator in Building (Community Room)",
+  amenities: "Parking, Elevator in Building, Community Room",
   buildingAddress: {
     city: "Detroit",
     state: "MI",
@@ -20,7 +20,7 @@ const treymoreProperty: PropertySeedType = {
   },
   petPolicy: "No Pets Allowed",
   unitAmenities:
-    "Air Conditioning(Central Air Conditioning) Garbage Disposal Range Refrigerator (Coin Laundry Room in building)",
+    "Air Conditioning (Central Air Conditioning), Garbage Disposal, Range, Refrigerator, Coin Laundry Room in building",
   unitsAvailable: 4,
   yearBuilt: 1916,
   accessibility: "2 units are barrier free; 2 units are bi-level 1.5 bath",

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -234,6 +234,20 @@ export const ListingView = (props: ListingProps) => {
   )
 
   const applicationsClosed = moment() > moment(listing.applicationDueDate)
+  const useMarkdownForPropertyAmenities = listing.amenities?.includes(",")
+  const useMarkdownForUnitAmenities = listing.unitAmenities?.includes(",")
+  const propertyAmenities = useMarkdownForPropertyAmenities
+    ? listing.amenities
+        .split(",")
+        .map((a) => `* ${a.trim()}`)
+        .join("\n")
+    : listing.amenities
+  const unitAmenities = useMarkdownForUnitAmenities
+    ? listing.unitAmenities
+        .split(",")
+        .map((a) => `* ${a.trim()}`)
+        .join("\n")
+    : listing.unitAmenities
 
   return (
     <article className="flex flex-wrap relative max-w-5xl m-auto">
@@ -351,10 +365,18 @@ export const ListingView = (props: ListingProps) => {
                   <Description term={t("t.petsPolicy")} description={listing.petPolicy} />
                 )}
                 {listing.amenities && (
-                  <Description term={t("t.propertyAmenities")} description={listing.amenities} />
+                  <Description
+                    term={t("t.propertyAmenities")}
+                    description={propertyAmenities}
+                    markdown={useMarkdownForPropertyAmenities}
+                  />
                 )}
                 {listing.unitAmenities && (
-                  <Description term={t("t.unitAmenities")} description={listing.unitAmenities} />
+                  <Description
+                    term={t("t.unitAmenities")}
+                    description={unitAmenities}
+                    markdown={useMarkdownForUnitAmenities}
+                  />
                 )}
                 {listing.servicesOffered && (
                   <Description

--- a/ui-components/src/text/Description.scss
+++ b/ui-components/src/text/Description.scss
@@ -45,6 +45,13 @@
       @apply w-2/3;
     }
 
+    ul {
+      padding-left: 1em;
+      li {
+        list-style-type: disc;
+      }
+    }
+
     &:last-of-type {
       @apply w-full;
     }


### PR DESCRIPTION
## Issue

- Addresses #812

## Description

This PR updates the seeding script to comma separate the amenities fields, and modify the UI to use a bulleted list based on the comma separations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Reseed the database, and navigate to one of the listings with amenities specified

### Desktop:
![localhost_3000_listing_75139ed5-c2d4-43c4-8ab5-2980e2a4780e_oak_village_independence_4401_burlingame_st_detroit_mi](https://user-images.githubusercontent.com/66751489/145254380-735d17aa-8574-47b8-9504-dcecb5183ada.png)

### Mobile:
![localhost_3000_listing_75139ed5-c2d4-43c4-8ab5-2980e2a4780e_oak_village_independence_4401_burlingame_st_detroit_mi (1)](https://user-images.githubusercontent.com/66751489/145254427-96d33f25-3956-41d9-a510-4014ec14ece8.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
