### PR TITLE
Fix checkbox rtl style

### DIFF
--- a/ui-components/src/global/forms.scss
+++ b/ui-components/src/global/forms.scss
@@ -93,8 +93,7 @@
   input[type="checkbox"] + label,
   input[type="radio"] + label {
     cursor: pointer;
-    // margin-bottom: 0.5em;
-    margin-left: 2rem;
+    margin-inline-start: 2rem;
     display: block;
     text-indent: -2rem;
   }
@@ -108,7 +107,7 @@
     display: inline-block;
     height: 1.25rem;
     line-height: 0.8;
-    margin-right: 0.8em;
+    margin-inline-end: 0.8em;
     text-indent: 0.15em;
     vertical-align: 0.2em;
     width: 1.25rem;


### PR DESCRIPTION
## Issue

- Closes #issue
- Addresses #issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Fixes the rtl styles for checkboxes by changing margin-left/margin-right to margin-inline-start/margin-inline-end

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

### Before
![image](https://user-images.githubusercontent.com/371177/145659164-73f3e549-c838-4181-b19b-9f6c15339898.png)

### After
![image](https://user-images.githubusercontent.com/371177/145659170-3a0c18a2-ca38-41bf-ae29-12e22d2e9fbe.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
