### PR TITLE
fix: update questionnaire stepper styling

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -266,6 +266,29 @@ li.progress-nav__item {
   width: 20%;
 }
 
+.progress-nav__item {
+  &.is-active:before {
+    @apply bg-primary-dark;
+  }
+  &.is-disabled:before {
+    @apply bg-white border-2 border-primary;
+  }
+  &:before {
+    @apply bg-primary border-0;
+  }
+  &:after {
+    @apply bg-primary;
+    height: 2px;
+    margin-top: -1px; // so the connecting line is vertically centered between the pips
+  }
+  &.is-active > a {
+    @apply text-primary-dark;
+  }
+  a {
+    @apply text-primary;
+  }
+}
+
 // Body text should have normal font weight
 .field-note {
   @apply font-normal;


### PR DESCRIPTION
## Issue

- Closes #829

## Description

This PR tweaks the styling on the questionnaire stepper to match the [mocks](https://www.figma.com/file/wAhoXVmHRIJ2TyBKFVq2JY/Desktop-and-Mobile-Experiences?node-id=3540%3A13497).

### Desktop
![localhost_3000_eligibility_household (2)](https://user-images.githubusercontent.com/66751489/145882907-ad8f04b0-6621-4001-bba7-5121e2789a32.png)

### Mobile
![localhost_3000_eligibility_household (3)](https://user-images.githubusercontent.com/66751489/145882922-aff98350-5476-436b-9a68-51d941bee3fc.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Navigate to the eligibility questionnaire.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
