### PR TITLE
Tweak HorizontalScroll button styles

### DIFF
--- a/sites/public/lib/HorizontalScrollSection.module.scss
+++ b/sites/public/lib/HorizontalScrollSection.module.scss
@@ -73,7 +73,11 @@ $icon-large: 40px;
 }
 
 .title button.title__button[disabled] svg {
-  fill-opacity: 40%;
+  fill-opacity: 20%;
+}
+
+.title button.title__button:hover svg {
+  fill: $tailwind-primary-darker;
 }
 
 .content {


### PR DESCRIPTION
## Description

Tweak the HorizontalScroll button styles. This fixes the buttons filling with white on hover due to my updates to the default button styles.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

### Screenshot:
![image](https://user-images.githubusercontent.com/371177/146283880-4ff2599c-9634-45ad-82b0-bf8352259ef6.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
