### PR TITLE
feat: support neighborhood filter on backend

### DIFF
--- a/backend/core/src/listings/dto/filter-type-to-field-map.ts
+++ b/backend/core/src/listings/dto/filter-type-to-field-map.ts
@@ -53,4 +53,5 @@ export const filterTypeToFieldMap: Record<keysWithMappedField, string> = {
   grabBars: "features.grabBars",
   heatingInUnit: "features.heatingInUnit",
   acInUnit: "features.acInUnit",
+  neighborhood: "property.neighborhood",
 }

--- a/backend/core/src/listings/dto/listing-filter-params.ts
+++ b/backend/core/src/listings/dto/listing-filter-params.ts
@@ -237,5 +237,15 @@ export class ListingFilterParams extends BaseFilter {
   })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsBooleanString({ groups: [ValidationsGroupsEnum.default] })
-  [ListingFilterKeys.acInUnit]?: boolean
+  [ListingFilterKeys.acInUnit]?: boolean;
+
+  @Expose()
+  @ApiProperty({
+    type: String,
+    example: "Forest Park, Elmwood Park",
+    required: false,
+  })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  [ListingFilterKeys.neighborhood]?: string
 }

--- a/backend/core/src/listings/types/listing-filter-keys-enum.ts
+++ b/backend/core/src/listings/types/listing-filter-keys-enum.ts
@@ -23,6 +23,7 @@ export enum ListingFilterKeys {
   grabBars = "grabBars",
   heatingInUnit = "heatingInUnit",
   acInUnit = "acInUnit",
+  neighborhood = "neighborhood",
 }
 
 export enum AvailabilityFilterEnum {

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -27,6 +27,7 @@ import { ListingUpdateDto } from "../../src/listings/dto/listing-update.dto"
 import { ListingPublishedCreateDto } from "../../src/listings/dto/listing-published-create.dto"
 import { UnitCreateDto } from "../../src/units/dto/unit-create.dto"
 import { AddressCreateDto } from "../../src/shared/dto/address.dto"
+import { threadId } from "worker_threads"
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dbOptions = require("../../ormconfig.test")
@@ -124,6 +125,26 @@ describe("Listings", () => {
     const query = qs.stringify(queryParams)
     const res = await supertest(app.getHttpServer()).get(`/listings?${query}`).expect(200)
     expect(res.body.items.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("should return listings with matching neighborhoods", async () => {
+    const queryParams = {
+      limit: "all",
+      filter: [
+        {
+          $comparison: "IN",
+          neighborhood: "Forest Park",
+        },
+      ],
+    }
+    const query = qs.stringify(queryParams)
+
+    const res = await supertest(app.getHttpServer()).get(`/listings?${query}`).expect(200)
+
+    expect(res.body.items.length).toBeGreaterThanOrEqual(1)
+    for (const listing of res.body.items) {
+      expect(listing.neighborhood).toEqual("Forest Park")
+    }
   })
 
   it("should modify property related fields of a listing and return a modified value", async () => {

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4862,6 +4862,9 @@ export interface ListingFilterParams {
 
   /**  */
   acInUnit?: boolean
+
+  /**  */
+  neighborhood?: string
 }
 
 export interface PaginatedListing {

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -28,6 +28,7 @@ function getComparisonForFilter(filterKey: ListingFilterKeys) {
       return EnumListingFilterParamsComparison["<="]
     case ListingFilterKeys.bedrooms:
     case ListingFilterKeys.zipcode:
+    case ListingFilterKeys.neighborhood:
       return EnumListingFilterParamsComparison["IN"]
     case ListingFilterKeys.seniorHousing:
     case ListingFilterKeys.independentLivingHousing:
@@ -101,6 +102,7 @@ export interface ListingFilterState {
   [FrontendListingFilterStateKeys.grabBars]?: string | boolean
   [FrontendListingFilterStateKeys.heatingInUnit]?: string | boolean
   [FrontendListingFilterStateKeys.acInUnit]?: string | boolean
+  [FrontendListingFilterStateKeys.neighborhood]?: string
 }
 
 // Since it'd be tricky to OR a separate ">=" comparison with an "IN"


### PR DESCRIPTION
## Issue

- Addresses #814

## Description

This commit adds a "neighborhood" key to the list of supported filters, and hooks it up to the property.neighborhood field of listings in the database.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Navigate to http://localhost:3000/listings/filtered?page=1&neighborhood=Forest%20Park,%20Elmwood%20Park in a local build. You should see two results show up, one from each neighborhood specified in the URL.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [x] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
