### PR TITLE
Add neighborhood info to right rail

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -308,7 +308,7 @@ export const ListingView = (props: ListingProps) => {
           hideHeader={true}
           desktopClass="header-hidden"
         >
-          <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 h-full md:border border-gray-400 bg-white">
+          <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 md:border border-gray-400 bg-white">
             <div className="hidden md:block">
               <ListingUpdated listingUpdated={listing.updatedAt} />
               {openHouseEvents && <OpenHouseEvent events={openHouseEvents} />}
@@ -339,7 +339,12 @@ export const ListingView = (props: ListingProps) => {
                 website: listing.managementWebsite,
               }}
             />
-            {hasNonReferralMethods && !applicationsClosed && applySidebar()}
+            {listing.neighborhood && (
+              <section className="hidden md:block aside-block">
+                <h4 className="text-caps-underline">{t("listings.sections.neighborhoodTitle")}</h4>
+                <p>{listing.neighborhood}</p>
+              </section>
+            )}
           </aside>
         </ListingDetailItem>
 


### PR DESCRIPTION
## Issue

- Closes #596

## Description

Adds the neighborhood to the right rail. Also makes the right-rail not 100% height and removes the duplicate Apply Online button.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

![image](https://user-images.githubusercontent.com/371177/146841933-3bc25834-7b5c-4c6b-b975-3a7001f58e7d.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
