### PR TITLE
feat: connect region cards on homepage to filter

### DIFF
--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -10,6 +10,10 @@ import styles from "./index.module.scss"
 import { Listing } from "@bloom-housing/backend-core/types"
 import { getListings } from "../lib/helpers"
 import moment from "moment"
+import {
+  Region,
+  regionImageUrls,
+} from "@bloom-housing/ui-components/src/helpers/regionNeighborhoodMap"
 
 export default function Home({ latestListings }) {
   const blankAlertInfo = {
@@ -51,13 +55,13 @@ export default function Home({ latestListings }) {
   }
 
   // TODO(#674): Fill out region buttons with real data
-  const RegionButton = (props: { label: string; image?: string }) => (
+  const RegionButton = (props: { region: [string, Region] }) => (
     <a
       className={styles.region}
-      href="/listings"
-      style={{ backgroundImage: `url(${props.image})` }}
+      href={`/listings/filtered?page=1&${props.region[0]}=true`}
+      style={{ backgroundImage: `url(${regionImageUrls.get(props.region[1])})` }}
     >
-      <p className={styles.region__text}>{props.label}</p>
+      <p className={styles.region__text}>{props.region[1]}</p>
     </a>
   )
 
@@ -101,27 +105,9 @@ export default function Home({ latestListings }) {
         icon="map"
         className={styles.regions}
       >
-        {/* TODO(#674): Get official hosted images */}
-        <RegionButton
-          label="Downtown"
-          image="https://pbs.twimg.com/media/DSzZwQKVAAASkw_?format=jpg&name=large"
-        />
-        <RegionButton
-          label="Eastside"
-          image="https://d12kp1agyyb87s.cloudfront.net/wp-content/uploads/2019/10/image001.jpg"
-        />
-        <RegionButton
-          label="Westside"
-          image="https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Atkinson_avenue_historic_district.JPG/1920px-Atkinson_avenue_historic_district.JPG"
-        />
-        <RegionButton
-          label="Southwest"
-          image="https://www.theneighborhoods.org/sites/the-neighborhoods/files/2020-10/Southwest-Mural_1.jpg"
-        />
-        <RegionButton
-          label="Midtown - New Center"
-          image="https://cdn.pixabay.com/photo/2019/03/17/04/00/detroit-4060269_960_720.jpg"
-        />
+        {Object.entries(Region).map((region) => (
+          <RegionButton region={region} />
+        ))}
       </HorizontalScrollSection>
       <ConfirmationModal
         setSiteAlertMessage={(alertMessage, alertType) => setAlertInfo({ alertMessage, alertType })}

--- a/ui-components/src/helpers/regionNeighborhoodMap.ts
+++ b/ui-components/src/helpers/regionNeighborhoodMap.ts
@@ -6,6 +6,27 @@ export enum Region {
   westside = "Westside",
 }
 
+// TODO(#674): Get official hosted images
+export const regionImageUrls: Map<Region, string> = new Map([
+  [Region.downtown, "https://pbs.twimg.com/media/DSzZwQKVAAASkw_?format=jpg&name=large"],
+  [
+    Region.eastside,
+    "https://d12kp1agyyb87s.cloudfront.net/wp-content/uploads/2019/10/image001.jpg",
+  ],
+  [
+    Region.midtownNewCenter,
+    "https://cdn.pixabay.com/photo/2019/03/17/04/00/detroit-4060269_960_720.jpg",
+  ],
+  [
+    Region.southwest,
+    "https://www.theneighborhoods.org/sites/the-neighborhoods/files/2020-10/Southwest-Mural_1.jpg",
+  ],
+  [
+    Region.westside,
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Atkinson_avenue_historic_district.JPG/1920px-Atkinson_avenue_historic_district.JPG",
+  ],
+])
+
 export interface Neighborhood {
   name: string
   region: Region


### PR DESCRIPTION
## Issue

- Closes #815

## Description

This commit implements navigating to the correct filter when a region card is clicked on the home page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Click on the "Eastside" region button, observe the correct filtered URL.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
