### PR TITLE
fix: populate favorited listings for logged in user

### DIFF
--- a/backend/core/src/auth/passport-strategies/jwt.strategy.ts
+++ b/backend/core/src/auth/passport-strategies/jwt.strategy.ts
@@ -35,9 +35,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException()
     }
     const userId = payload.sub
-    return this.userRepository.findOne({
-      where: { id: userId },
-      relations: ["leasingAgentInListings"],
-    })
+    return this.userRepository
+      .createQueryBuilder("user")
+      .where("user.id = :id", { id: userId })
+      .leftJoinAndSelect("user.preferences", "user_preferences")
+      .leftJoinAndSelect("user_preferences.favorites", "favorited_listings")
+      .leftJoinAndSelect("user.leasingAgentInListings", "leasing_agent_in_listings")
+      .getOneOrFail()
   }
 }

--- a/backend/core/src/auth/passport-strategies/jwt.strategy.ts
+++ b/backend/core/src/auth/passport-strategies/jwt.strategy.ts
@@ -38,6 +38,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return this.userRepository
       .createQueryBuilder("user")
       .where("user.id = :id", { id: userId })
+      .leftJoinAndSelect("user.roles", "user_roles")
+      .leftJoinAndSelect("user.jurisdictions", "jurisdictions")
       .leftJoinAndSelect("user.preferences", "user_preferences")
       .leftJoinAndSelect("user_preferences.favorites", "favorited_listings")
       .leftJoinAndSelect("user.leasingAgentInListings", "leasing_agent_in_listings")

--- a/backend/core/src/migration/1640193850142-fix_user_preferences.ts
+++ b/backend/core/src/migration/1640193850142-fix_user_preferences.ts
@@ -1,32 +1,65 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class fixUserPreferences1640193850142 implements MigrationInterface {
-    name = 'fixUserPreferences1640193850142'
+  name = "fixUserPreferences1640193850142"
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_0115bda0994ab10a4c1a883504e"`);
-        await queryRunner.query(`DROP INDEX "IDX_0115bda0994ab10a4c1a883504"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" ADD "id" uuid NOT NULL DEFAULT uuid_generate_v4()`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_458057fa75b66e68a275647da2e"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_b3539e30273abb8b320977f8f8e" PRIMARY KEY ("user_id", "id")`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD "user_preferences_id" uuid NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_a2e38b75e1a538e046de2fba364"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_388b369f95a0d1d10a779599001" PRIMARY KEY ("user_preferences_user_id", "listings_id", "user_preferences_id")`);
-        await queryRunner.query(`CREATE INDEX "IDX_a82112eb1b514fecdac3f43ebe" ON "user_preferences_favorites_listings" ("user_preferences_id", "user_preferences_user_id") `);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0" FOREIGN KEY ("user_preferences_id", "user_preferences_user_id") REFERENCES "user_preferences"("id","user_id") ON DELETE CASCADE ON UPDATE CASCADE`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_0115bda0994ab10a4c1a883504e"`
+    )
+    await queryRunner.query(`DROP INDEX "IDX_0115bda0994ab10a4c1a883504"`)
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD "id" uuid NOT NULL DEFAULT uuid_generate_v4()`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_458057fa75b66e68a275647da2e"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_b3539e30273abb8b320977f8f8e" PRIMARY KEY ("user_id", "id")`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" ADD "user_preferences_id" uuid NOT NULL`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_a2e38b75e1a538e046de2fba364"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_388b369f95a0d1d10a779599001" PRIMARY KEY ("user_preferences_user_id", "listings_id", "user_preferences_id")`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a82112eb1b514fecdac3f43ebe" ON "user_preferences_favorites_listings" ("user_preferences_id", "user_preferences_user_id") `
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0" FOREIGN KEY ("user_preferences_id", "user_preferences_user_id") REFERENCES "user_preferences"("id","user_id") ON DELETE CASCADE ON UPDATE CASCADE`
+    )
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0"`);
-        await queryRunner.query(`DROP INDEX "IDX_a82112eb1b514fecdac3f43ebe"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_388b369f95a0d1d10a779599001"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_a2e38b75e1a538e046de2fba364" PRIMARY KEY ("user_preferences_user_id", "listings_id")`);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP COLUMN "user_preferences_id"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_b3539e30273abb8b320977f8f8e"`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_458057fa75b66e68a275647da2e" PRIMARY KEY ("user_id")`);
-        await queryRunner.query(`ALTER TABLE "user_preferences" DROP COLUMN "id"`);
-        await queryRunner.query(`CREATE INDEX "IDX_0115bda0994ab10a4c1a883504" ON "user_preferences_favorites_listings" ("user_preferences_user_id") `);
-        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_0115bda0994ab10a4c1a883504e" FOREIGN KEY ("user_preferences_user_id") REFERENCES "user_preferences"("user_id") ON DELETE CASCADE ON UPDATE CASCADE`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0"`
+    )
+    await queryRunner.query(`DROP INDEX "IDX_a82112eb1b514fecdac3f43ebe"`)
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_388b369f95a0d1d10a779599001"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_a2e38b75e1a538e046de2fba364" PRIMARY KEY ("user_preferences_user_id", "listings_id")`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" DROP COLUMN "user_preferences_id"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_b3539e30273abb8b320977f8f8e"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_458057fa75b66e68a275647da2e" PRIMARY KEY ("user_id")`
+    )
+    await queryRunner.query(`ALTER TABLE "user_preferences" DROP COLUMN "id"`)
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0115bda0994ab10a4c1a883504" ON "user_preferences_favorites_listings" ("user_preferences_user_id") `
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_0115bda0994ab10a4c1a883504e" FOREIGN KEY ("user_preferences_user_id") REFERENCES "user_preferences"("user_id") ON DELETE CASCADE ON UPDATE CASCADE`
+    )
+  }
 }

--- a/backend/core/src/migration/1640193850142-fix_user_preferences.ts
+++ b/backend/core/src/migration/1640193850142-fix_user_preferences.ts
@@ -1,0 +1,32 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class fixUserPreferences1640193850142 implements MigrationInterface {
+    name = 'fixUserPreferences1640193850142'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_0115bda0994ab10a4c1a883504e"`);
+        await queryRunner.query(`DROP INDEX "IDX_0115bda0994ab10a4c1a883504"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" ADD "id" uuid NOT NULL DEFAULT uuid_generate_v4()`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_458057fa75b66e68a275647da2e"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_b3539e30273abb8b320977f8f8e" PRIMARY KEY ("user_id", "id")`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD "user_preferences_id" uuid NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_a2e38b75e1a538e046de2fba364"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_388b369f95a0d1d10a779599001" PRIMARY KEY ("user_preferences_user_id", "listings_id", "user_preferences_id")`);
+        await queryRunner.query(`CREATE INDEX "IDX_a82112eb1b514fecdac3f43ebe" ON "user_preferences_favorites_listings" ("user_preferences_id", "user_preferences_user_id") `);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0" FOREIGN KEY ("user_preferences_id", "user_preferences_user_id") REFERENCES "user_preferences"("id","user_id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "FK_a82112eb1b514fecdac3f43ebe0"`);
+        await queryRunner.query(`DROP INDEX "IDX_a82112eb1b514fecdac3f43ebe"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP CONSTRAINT "PK_388b369f95a0d1d10a779599001"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "PK_a2e38b75e1a538e046de2fba364" PRIMARY KEY ("user_preferences_user_id", "listings_id")`);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" DROP COLUMN "user_preferences_id"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" DROP CONSTRAINT "PK_b3539e30273abb8b320977f8f8e"`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" ADD CONSTRAINT "PK_458057fa75b66e68a275647da2e" PRIMARY KEY ("user_id")`);
+        await queryRunner.query(`ALTER TABLE "user_preferences" DROP COLUMN "id"`);
+        await queryRunner.query(`CREATE INDEX "IDX_0115bda0994ab10a4c1a883504" ON "user_preferences_favorites_listings" ("user_preferences_user_id") `);
+        await queryRunner.query(`ALTER TABLE "user_preferences_favorites_listings" ADD CONSTRAINT "FK_0115bda0994ab10a4c1a883504e" FOREIGN KEY ("user_preferences_user_id") REFERENCES "user_preferences"("user_id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+}

--- a/backend/core/src/user-preferences/entities/user-preferences.entity.ts
+++ b/backend/core/src/user-preferences/entities/user-preferences.entity.ts
@@ -1,25 +1,39 @@
 import { User } from "../../../src/auth/entities/user.entity"
-import { Column, Entity, JoinColumn, JoinTable, ManyToMany, OneToOne } from "typeorm"
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm"
 import { Expose, Type } from "class-transformer"
 import { Listing } from "../../../src/listings/entities/listing.entity"
-import { IsOptional } from "class-validator"
+import { IsOptional, IsUUID } from "class-validator"
 import { ValidationsGroupsEnum } from "../../../src/shared/types/validations-groups-enum"
 
 @Entity({ name: "user_preferences" })
-export class UserPreferences {
-  @OneToOne(() => User, (user) => user.preferences, {
-    primary: true,
-  })
+export class UserPreferences extends BaseEntity {
+  @PrimaryGeneratedColumn("uuid")
+  @Expose()
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  id: string
+
+  @OneToOne(() => User, (user) => user.preferences, { primary: true })
   @JoinColumn()
   user: User
 
   @Column("boolean", { default: false })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @Expose()
-  sendEmailNotifications?: boolean
+  sendEmailNotifications?: boolean | null
 
   @Column("boolean", { default: false })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @Expose()
-  sendSmsNotifications?: boolean
+  sendSmsNotifications?: boolean | null
 
   @ManyToMany(() => Listing, (listing) => listing.favoritedPreferences, { nullable: true })
   @JoinTable()


### PR DESCRIPTION
## Issue

- Addresses #78
- [x] This change is a dependency for another issue

## Description

The preferences.favorites field was not being populated for the logged in user, due to a missing left join in the query.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Check out #882, cherry-pick this change, log in, favorite a listing, and then refresh the page. You should see that listing remain "favorited".

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
