### PR TITLE
Add support for sending new-listing notifications to opted-in users when a listing's status is updated from not-active to active

### DIFF
--- a/backend/core/src/listings/listings-notifications.ts
+++ b/backend/core/src/listings/listings-notifications.ts
@@ -22,18 +22,11 @@ export class ListingsNotificationsConsumer {
   @Process()
   async sendListingNotifications(job: Job<ListingNotificationInfo>): Promise<StatusDto> {
     const listing: Listing = job.data.listing
-    let status: StatusDto
-    if (job.data.updateType === ListingUpdateType.CREATE) {
-      status = await this.smsService.sendNewListingNotification(listing)
+    const status: StatusDto = await this.smsService.sendNewListingNotification(listing)
 
-      // TODO(https://github.com/CityOfDetroit/bloom/issues/698): call out to the
-      // emailService to send email notifications.
-    } else if (job.data.updateType === ListingUpdateType.MODIFY) {
-      status = await this.smsService.sendNewListingNotification(listing)
+    // TODO(https://github.com/CityOfDetroit/bloom/issues/698): call out to the
+    // emailService to send email notifications.
 
-      // TODO(https://github.com/CityOfDetroit/bloom/issues/698): call out to the
-      // emailService to send email notifications.
-    }
     return status
   }
 }

--- a/backend/core/src/listings/listings-notifications.ts
+++ b/backend/core/src/listings/listings-notifications.ts
@@ -29,7 +29,10 @@ export class ListingsNotificationsConsumer {
       // TODO(https://github.com/CityOfDetroit/bloom/issues/698): call out to the
       // emailService to send email notifications.
     } else if (job.data.updateType === ListingUpdateType.MODIFY) {
-      // TODO(#698 and #705): send sms and email notifications for modified listings
+      status = await this.smsService.sendNewListingNotification(listing)
+
+      // TODO(https://github.com/CityOfDetroit/bloom/issues/698): call out to the
+      // emailService to send email notifications.
     }
     return status
   }


### PR DESCRIPTION
## Issue

- Addresses #705 

## Description

This change adds a hook to the update-listing flow to trigger an asynchronous process to send notifications about the updated listing to all users who are opted-in for SMS alerts. The notifications are only sent if the listing's status changes from "anything other than active" to "active".

Note: this change simplifies the implementation of `sendListingNotifications`: we now send the same new-listing notification regardless of whether we're dealing with a newly created-listing or a listing that was just updated to be "active". From the user's perspective, they're equivalent (the listing wasn't showing up on the site; now it is).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd backend/core && yarn test`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
