### PR TITLE
fix: add hearing mobility visual to a11y features

### DIFF
--- a/shared-helpers/src/formKeys.ts
+++ b/shared-helpers/src/formKeys.ts
@@ -251,4 +251,7 @@ export const listingFeatures = {
   grabBars: "Grab Bars",
   heatingInUnit: "Heating in Unit",
   acInUnit: "AC in Unit",
+  hearing: "Hearing",
+  mobility: "Mobility",
+  visual: "Visual",
 }

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailBuildingFeatures.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailBuildingFeatures.tsx
@@ -43,7 +43,7 @@ const DetailBuildingFeatures = () => {
       </GridSection>
       <GridSection columns={1}>
         <GridCell>
-          <ViewItem id="accessibility" label={t("t.accessibility")}>
+          <ViewItem id="accessibility" label={t("t.additionalAccessibility")}>
             {getDetailFieldString(listing.accessibility)}
           </ViewItem>
         </GridCell>

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -150,7 +150,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
       setUnitsSummaries(tempSummaries)
     }
 
-    if (listing.isVerified === false) {
+    if (listing?.isVerified === false) {
       setVerifyAlert(true)
     }
   }, [

--- a/sites/partners/src/listings/PaperListingForm/sections/BuildingFeatures.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/BuildingFeatures.tsx
@@ -41,7 +41,7 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             maxLength={600}
           />
           <Textarea
-            label={t("t.accessibility")}
+            label={t("t.additionalAccessibility")}
             name={"accessibility"}
             id={"accessibility"}
             fullWidth={true}

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -468,24 +468,21 @@ export const ListingView = (props: ListingProps) => {
                     markdown={useMarkdownForUnitAmenities}
                   />
                 )}
-                <Description
-                  term={t("t.accessibility")}
-                  description={
-                    accessibilityFeatures
-                      ? accessibilityFeatures
-                      : listing.accessibility ?? t("t.contactPropertyManagement")
-                  }
-                />
                 {listing.servicesOffered && (
                   <Description
                     term={t("t.servicesOffered")}
                     description={listing.servicesOffered}
                   />
                 )}
-                <Description
-                  term={t("t.accessibility")}
-                  description={listing.accessibility || t("t.contactPropertyManagement")}
-                />
+                {accessibilityFeatures && (
+                  <Description term={t("t.accessibility")} description={accessibilityFeatures} />
+                )}
+                {listing.accessibility && (
+                  <Description
+                    term={t("t.additionalAccessibility")}
+                    description={listing.accessibility}
+                  />
+                )}
                 {/* <Description
                   term={t("t.unitFeatures")}
                   description={

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1626,6 +1626,7 @@
     "additionalPhone": "Additional Phone",
     "area": "area",
     "areYouStillWorking": "Are you still working?",
+    "additionalAccessibility": "Additional Accessibility",
     "accessibility": "Accessibility",
     "am": "AM",
     "available": "available",


### PR DESCRIPTION
## Issue

- Closes #1028 
- [x] This change has a dependency from another issue

## Description

Add hearing, mobility, visual to the accessibility building features (checkbox set)
Rename the existing a11y text field to `Additional Accessibility`
Remove the default text on the `Additional Accessibility` field (`Contact property management`) so that it does not show at all if nothing was entered

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Check partners for the 3 new checkboxes in a11y features on edit and details
Check public for the new bullets, and add/remove the a11y textbox and ensure it adds/removes and has the new header

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
