### PR TITLE
fix: hide hmi link if no hmi table

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -295,9 +295,13 @@ export const ListingView = (props: ListingProps) => {
             />
             <div className="text-sm leading-5 mt-4 invisible md:visible">
               {t("listings.unitSummaryGroupMessage")}{" "}
-              <a className="underline" href="#household_maximum_income_summary">
-                {t("listings.unitSummaryGroupLinkText")}
-              </a>
+              {hmiData ? (
+                <a className="underline" href="#household_maximum_income_summary">
+                  {t("listings.unitSummaryGroupLinkText")}
+                </a>
+              ) : (
+                t("listings.unitSummaryGroupLinkText")
+              )}
             </div>
           </>
         )}

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -293,16 +293,14 @@ export const ListingView = (props: ListingProps) => {
               data={[{ data: groupedUnitData }]}
               responsiveCollapse={true}
             />
-            <div className="text-sm leading-5 mt-4 invisible md:visible">
-              {t("listings.unitSummaryGroupMessage")}{" "}
-              {hmiData ? (
+            {hmiData.length > 0 && (
+              <div className="text-sm leading-5 mt-4 invisible md:visible">
+                {t("listings.unitSummaryGroupMessage")}{" "}
                 <a className="underline" href="#household_maximum_income_summary">
                   {t("listings.unitSummaryGroupLinkText")}
                 </a>
-              ) : (
-                t("listings.unitSummaryGroupLinkText")
-              )}
-            </div>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Description

Hide maximum income blurb and link if there is no HMI table / data available amongst the unit groups

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Create a unit group with no AMI levels, no text should show
Create a unit group with enough AMI info to render the table (an ami chart, ami percentage, and occupancy range), text should show

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
