### PR TITLE
fix: fix for when rent range was empty

### DIFF
--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -33,7 +33,7 @@ export const getUnitGroupSummary = (unitGroups: UnitGroup[] = []): UnitGroupSumm
     let rentAsPercentIncomeRange: MinMax, rentRange: MinMax, amiPercentageRange: MinMax
     group.amiLevels.forEach((level) => {
       if (level.monthlyRentDeterminationType === MonthlyRentDeterminationType.flatRent) {
-        rentRange = setMinMax(rentRange, Number(level.flatRentValue))
+        rentRange = setMinMax(rentRange, level.flatRentValue)
       } else {
         rentAsPercentIncomeRange = setMinMax(
           rentAsPercentIncomeRange,
@@ -49,8 +49,8 @@ export const getUnitGroupSummary = (unitGroups: UnitGroup[] = []): UnitGroupSumm
         .map((type) => type.name),
       rentAsPercentIncomeRange,
       rentRange: rentRange && {
-        min: `$${rentRange.min}`,
-        max: `$${rentRange.max}`,
+        min: rentRange.min ? `$${rentRange.min}` : "",
+        max: rentRange.max ? `$${rentRange.max}` : "",
       },
       amiPercentageRange,
       openWaitlist: group.openWaitlist,


### PR DESCRIPTION
This fixes when rent range was empty on a 

Best way to verify this:

create or edit a listing
add a unit group, and add ami levels but do not add a rent to the ami level
save the listing
view the preview (or take a look at it on the public site)
under `RENT` on the table, it should be empty
