### PR TITLE
fix: preview close alert style fixes

### DIFF
--- a/sites/public/pages/preview/listings/[id].tsx
+++ b/sites/public/pages/preview/listings/[id].tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react"
+import React from "react"
 import Head from "next/head"
 import axios from "axios"
 import { Listing } from "@bloom-housing/backend-core/types"
-import { t } from "@bloom-housing/ui-components"
+import { t, AlertBox } from "@bloom-housing/ui-components"
 import { imageUrlFromListing } from "@bloom-housing/shared-helpers"
 
 import Layout from "../../../layouts/application"
@@ -15,7 +15,6 @@ interface ListingProps {
 
 export default function ListingPage(props: ListingProps) {
   const { listing } = props
-  const [previewBarVisible, setPreviewBarVisible] = useState(true)
   const pageTitle = `${listing.name} - ${t("nav.siteTitle")}`
   const metaDescription = t("pageDescription.listing", {
     regionName: t("region.name"),
@@ -29,19 +28,15 @@ export default function ListingPage(props: ListingProps) {
         <title>{pageTitle}</title>
       </Head>
       <MetaTags title={listing.name} image={metaImage} description={metaDescription} />
-      {previewBarVisible && (
-        <div className="pt-6 pb-4 bg-red-700 text-white font-bold text-sm">
-          <div className="max-w-5xl m-auto">{t("listings.listingPreviewOnly")}</div>
-          <button
-            className="-mt-8 alert-box__close text-white"
-            onClick={() => {
-              setPreviewBarVisible(false)
-            }}
-          >
-            &times;
-          </button>
-        </div>
-      )}
+      <AlertBox
+        className="pt-4 pb-4 bg-red-700 font-bold text-sm"
+        type="alert"
+        boundToLayoutWidth
+        inverted
+        closeable
+      >
+        {t("listings.listingPreviewOnly")}
+      </AlertBox>
       <ListingView listing={listing} preview={false} />
     </Layout>
   )

--- a/ui-components/src/notifications/AlertBox.scss
+++ b/ui-components/src/notifications/AlertBox.scss
@@ -1,10 +1,10 @@
 .alert-box {
   @apply relative;
-  @apply p-4;
+  @apply py-3;
+  @apply px-4;
   @apply leading-snug;
   @apply flex;
   @apply items-center;
-  max-height: 50px;
 
   .alert-box_inner {
     @apply m-auto;
@@ -23,6 +23,9 @@
   // Inverts color scheme of alert
   &.invert {
     @apply text-white;
+    svg {
+      fill: white;
+    }
 
     .close {
       @apply text-white;
@@ -78,9 +81,9 @@
 }
 
 .alert-box__close {
-  @apply text-3xl;
-  line-height: 1rem;
+  @apply text-4xl;
   right: 1rem;
   @apply ml-3;
   @apply p-0;
+  line-height: 1rem;
 }

--- a/ui-components/src/notifications/AlertBox.tsx
+++ b/ui-components/src/notifications/AlertBox.tsx
@@ -52,6 +52,7 @@ const AlertBox = (props: AlertBoxProps) => {
               size="medium"
               symbol={icons[props.type || "alert"]}
               fill={props.inverted ? IconFillColors.white : undefined}
+              ariaHidden={true}
             />
           </span>
           <span className="alert-box__body">
@@ -63,8 +64,9 @@ const AlertBox = (props: AlertBoxProps) => {
           <button
             className={`alert-box__close ${props.inverted ? "text-white" : ""}`}
             onClick={onClose}
+            aria-label="close alert"
           >
-            &times;
+            <span aria-hidden={true}>&times;</span>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Description
Brings over the preview alert box fixes from core

![Screen Shot 2022-03-10 at 5 19 14 PM](https://user-images.githubusercontent.com/65367387/157777486-dcfd8107-6429-40e2-bfa0-7d9579e247e0.png)
![Screen Shot 2022-03-10 at 5 18 23 PM](https://user-images.githubusercontent.com/65367387/157777485-67989a74-d989-44bd-b856-ae015f2c846d.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Look at a preview listing, you can also check existing alert boxes by trying to visit /user without being signed in

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
