### PR TITLE
fix: stray zero if no programs

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -392,7 +392,7 @@ export const ListingView = (props: ListingProps) => {
                   />
                 </ListSection>
               )}
-              {listing.listingPrograms?.length && (
+              {listing.listingPrograms?.length > 0 && (
                 <ListSection
                   title={t("listings.communityPrograms")}
                   subtitle={t("listings.communityProgramsDescription")}


### PR DESCRIPTION
## Description

![Screen Shot 2022-03-10 at 5 42 25 PM](https://user-images.githubusercontent.com/65367387/157779658-503a24d0-d192-4de6-8a5b-bf9daa623f45.png)

## How Can This Be Tested/Reviewed?

Create a listing with a unit group with occupancy and no programs, there should be no stray zero

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
