### PR TITLE
fix: fixes pagination issue on detroit user grid

### DIFF
--- a/backend/core/src/auth/services/user.service.ts
+++ b/backend/core/src/auth/services/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
     qb.andWhere("user.id IN (:...distinctIDs)", {
       distinctIDs: distinctIDResult.items.map((elem) => elem.id),
     })
-    qb.orderBy("user.id")
+
     const result = await qb.getMany()
     /**
      * admin are the only ones that can access all users

--- a/backend/core/src/auth/services/user.service.ts
+++ b/backend/core/src/auth/services/user.service.ts
@@ -102,8 +102,9 @@ export class UserService {
     }
     // https://www.npmjs.com/package/nestjs-typeorm-paginate
     const distinctIDQB = this._getQb(false)
-    distinctIDQB.addSelect("user.id")
+    distinctIDQB.select("user.id")
     distinctIDQB.groupBy("user.id")
+    distinctIDQB.orderBy("user.id")
     const qb = this._getQb()
 
     if (params.filter) {
@@ -123,6 +124,7 @@ export class UserService {
     qb.andWhere("user.id IN (:...distinctIDs)", {
       distinctIDs: distinctIDResult.items.map((elem) => elem.id),
     })
+    qb.orderBy("user.id")
     const result = await qb.getMany()
     /**
      * admin are the only ones that can access all users


### PR DESCRIPTION
## Description
This resolves the pagination issue that has plagued the detroit user grid

the cause of the issue turned out to be the following: https://stackoverflow.com/questions/30038587/how-does-postgres-order-the-results-when-order-by-is-not-provided#:~:text=If%20no%20order%20by%20clause,or%20directly%20from%20the%20table).

basically that postgres when no order by is given returns records in the order it got them. Which could cause a mismatch across pages of data as each page is fetched in isolation. Adding the ORDER BYs thus enforces a consistent ordering and avoids the problem

## How Can This Be Tested/Reviewed?
aim your local at live/dev detroit DBs
log in as a user that has access to the user grid in partners
fun part: sift through the user grid and verify that each of the users in that list are unique and covers the 148 users that should show up on live 

helpful query:
```
SELECT 
    u.id AS user_id,
    u.email
FROM user_accounts u 
    LEFT JOIN listings_leasing_agents_user_accounts listings_user ON listings_user.user_accounts_id=u.id 
    LEFT JOIN listings listings ON listings.id=listings_user.listings_id  
    LEFT JOIN user_roles user_roles ON user_roles.user_id=u.id 
WHERE (user_roles.is_partner = true OR user_roles.is_admin = true) 
GROUP BY u.id
ORDER BY u.id
```
^ query that shows the users that should show on the grid