### PR TITLE
fix: verify link should work on second application tab

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -72,6 +72,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
   const [tabIndex, setTabIndex] = useState(0)
   const [alert, setAlert] = useState<AlertErrorType | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
+  const [jumpToVerify, setJumpToVerify] = useState<boolean>(false)
   const [units, setUnits] = useState<TempUnit[]>([])
   const [unitsSummaries, setUnitsSummaries] = useState<TempUnitsSummary[]>([])
   const [openHouseEvents, setOpenHouseEvents] = useState<TempEvent[]>([])
@@ -148,6 +149,17 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
       setUnitsSummaries(tempSummaries)
     }
   }, [])
+
+  const scrollToVerify = () => {
+    document.getElementById("isVerifiedContainer").scrollIntoView({ behavior: "smooth" })
+  }
+
+  useEffect(() => {
+    if (jumpToVerify && tabIndex === 0) {
+      scrollToVerify()
+      setJumpToVerify(false)
+    }
+  }, [tabIndex])
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { getValues, setError, clearErrors, reset } = formMethods
@@ -333,10 +345,12 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                         href="#"
                         onClick={async (e) => {
                           e.preventDefault()
-                          await setTabIndex(0)
-                          document
-                            .getElementById("isVerifiedContainer")
-                            .scrollIntoView({ behavior: "smooth" })
+                          if (tabIndex === 1) {
+                            setJumpToVerify(true)
+                            setTabIndex(0)
+                          } else {
+                            scrollToVerify()
+                          }
                         }}
                       >
                         Verify your listing data.

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -159,7 +159,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
       scrollToVerify()
       setJumpToVerify(false)
     }
-  }, [tabIndex])
+  }, [tabIndex, jumpToVerify])
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { getValues, setError, clearErrors, reset } = formMethods
@@ -343,7 +343,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                       <a
                         className="decoration-blue-700 underline"
                         href="#"
-                        onClick={async (e) => {
+                        onClick={(e) => {
                           e.preventDefault()
                           if (tabIndex === 1) {
                             setJumpToVerify(true)

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -331,8 +331,9 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                       <a
                         className="decoration-blue-700 underline"
                         href="#"
-                        onClick={(e) => {
+                        onClick={async (e) => {
                           e.preventDefault()
+                          await setTabIndex(0)
                           document
                             .getElementById("isVerifiedContainer")
                             .scrollIntoView({ behavior: "smooth" })


### PR DESCRIPTION
## Issue

- Closes #1055 

## Description

Clicking on the `Verify your listing data` link in the alert box at the top of the listing form for an unverified listing while on the second tab of the application should change you to the first page and then scroll to the bottom as it does now for the first tab.

## How Can This Be Tested/Reviewed?

Click on the verify link from the second page of the form, ensure it scrolls to the verify field

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
