### PR TITLE
feat: adds unit summaries to listings list to backend

### DIFF
--- a/backend/core/src/listings/listings.module.ts
+++ b/backend/core/src/listings/listings.module.ts
@@ -25,6 +25,7 @@ import { AmiChart } from "../ami-charts/entities/ami-chart.entity"
 import { SmsModule } from "../sms/sms.module"
 import { ListingFeatures } from "./entities/listing-features.entity"
 import { ActivityLogModule } from "../activity-log/activity-log.module"
+import { UnitGroup } from "../units-summary/entities/unit-group.entity"
 
 interface RedisCache extends Cache {
   store: RedisStore
@@ -61,6 +62,7 @@ if (process.env.REDIS_USE_TLS !== "0") {
       Property,
       AmiChart,
       ListingFeatures,
+      UnitGroup,
     ]),
     AuthModule,
     TranslationsModule,

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -39,7 +39,7 @@ export class ListingsService {
     @Inject(REQUEST) private req: ExpressRequest,
     @InjectRepository(Listing) private readonly listingRepository: Repository<Listing>,
     @InjectRepository(AmiChart) private readonly amiChartsRepository: Repository<AmiChart>,
-    @InjectRepository(UnitGroup) private readonly unitGrouopRepository: Repository<UnitGroup>,
+    @InjectRepository(UnitGroup) private readonly unitGroupRepository: Repository<UnitGroup>,
     private readonly translationService: TranslationsService,
     @InjectQueue("listings-notifications")
     private listingsNotificationsQueue: Queue<ListingNotificationInfo>
@@ -157,7 +157,7 @@ export class ListingsService {
   }
 
   private async addUnitSummariesToListings(listings: Listing[]) {
-    const res = await this.unitGrouopRepository.find({
+    const res = await this.unitGroupRepository.find({
       cache: true,
       where: {
         listing: {
@@ -166,15 +166,21 @@ export class ListingsService {
       },
     })
 
-    const unitGroupMap = res.reduce((obj, current) => {
-      if (obj[current.listingId] !== undefined) {
-        obj[current.listingId].push(current)
-      } else {
-        obj[current.listingId] = [current]
-      }
+    const unitGroupMap = res.reduce(
+      (
+        obj: Record<string, Array<UnitGroup>>,
+        current: UnitGroup
+      ): Record<string, Array<UnitGroup>> => {
+        if (obj[current.listingId] !== undefined) {
+          obj[current.listingId].push(current)
+        } else {
+          obj[current.listingId] = [current]
+        }
 
-      return obj
-    }, {})
+        return obj
+      },
+      {}
+    )
 
     // using map with {...listing, unitSummaries} throws a type error
     listings.forEach((listing) => {

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -39,6 +39,7 @@ export class ListingsService {
     @Inject(REQUEST) private req: ExpressRequest,
     @InjectRepository(Listing) private readonly listingRepository: Repository<Listing>,
     @InjectRepository(AmiChart) private readonly amiChartsRepository: Repository<AmiChart>,
+    @InjectRepository(UnitGroup) private readonly unitGrouopRepository: Repository<UnitGroup>,
     private readonly translationService: TranslationsService,
     @InjectQueue("listings-notifications")
     private listingsNotificationsQueue: Queue<ListingNotificationInfo>
@@ -112,7 +113,7 @@ export class ListingsService {
     }
     const view = getView(this.listingRepository.createQueryBuilder("listings"), params.view)
 
-    const listings = await view
+    let listings = await view
       .getViewQb()
       .andWhere("listings.id IN (" + innerFilteredQuery.getQuery() + ")")
       // Set the inner WHERE params on the outer query, as noted in the TypeORM docs.
@@ -121,6 +122,8 @@ export class ListingsService {
       .setParameters(innerFilteredQuery.getParameters())
       .orderBy(getOrderByCondition(params))
       .getMany()
+
+    listings = await this.addUnitSummariesToListings(listings)
 
     // Set pagination info
     const itemsPerPage = paginate ? (params.limit as number) : listings.length
@@ -151,6 +154,34 @@ export class ListingsService {
       },
     }
     return paginatedListings
+  }
+
+  private async addUnitSummariesToListings(listings: Listing[]) {
+    const res = await this.unitGrouopRepository.find({
+      cache: true,
+      where: {
+        listing: {
+          id: In(listings.map((listing) => listing.id)),
+        },
+      },
+    })
+
+    const unitGroupMap = res.reduce((obj, current) => {
+      if (obj[current.listingId] !== undefined) {
+        obj[current.listingId].push(current)
+      } else {
+        obj[current.listingId] = [current]
+      }
+
+      return obj
+    }, {})
+
+    // using map with {...listing, unitSummaries} throws a type error
+    listings.forEach((listing) => {
+      listing.unitSummaries = summarizeUnits(unitGroupMap[listing.id], [])
+    })
+
+    return listings
   }
 
   async create(listingDto: ListingCreateDto): Promise<Listing> {

--- a/backend/core/src/listings/tests/listings.service.spec.ts
+++ b/backend/core/src/listings/tests/listings.service.spec.ts
@@ -16,6 +16,7 @@ import { Compare } from "../../shared/dto/filter.dto"
 import { ListingFilterParams } from "../dto/listing-filter-params"
 import { OrderByFieldsEnum } from "../types/listing-orderby-enum"
 import { ContextIdFactory } from "@nestjs/core"
+import { UnitGroup } from "../../units-summary/entities/unit-group.entity"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
@@ -164,6 +165,14 @@ describe("ListingsService", () => {
         {
           provide: getRepositoryToken(AmiChart),
           useValue: jest.fn(),
+        },
+        {
+          provide: getRepositoryToken(UnitGroup),
+          useValue: {
+            find: jest.fn(() => {
+              return []
+            }),
+          },
         },
         {
           provide: TranslationsService,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10136.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10136.ts
@@ -95,7 +95,7 @@ export class Listing10136Seed extends ListingDefaultSeed {
       name: CountyCode.detroit,
     })
 
-    const unitGroups: Omit<UnitGroup, "id">[] = [
+    const unitGroups: Omit<UnitGroup, "id" | "listingId">[] = [
       {
         amiLevels: [],
         unitType: [unitTypeStudio, unitTypeOneBdrm],

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10151.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10151.ts
@@ -73,13 +73,7 @@ export class Listing10151Seed extends ListingDefaultSeed {
 
     const reservedType = await this.reservedTypeRepository.findOneOrFail({ name: "specialNeeds" })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId:
-          "https://images1.apartments.com/i2/Lzldwt350ozz-zuJtBQf3-V7EB0-hqEaz5ssWS4sCAI/112/martin-luther-king-apartments-detroit-mi-primary-photo.jpg?p=1",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10153.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10153.ts
@@ -69,12 +69,7 @@ export class Listing10153Seed extends ListingDefaultSeed {
       ...propertySeed,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "/images/dev/Morang Apartments.png",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10154.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10154.ts
@@ -72,12 +72,7 @@ export class Listing10154Seed extends ListingDefaultSeed {
       ...propertySeed,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "/images/dev/Morningside Commons.jpg",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10155.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10155.ts
@@ -69,12 +69,7 @@ export class Listing10155Seed extends ListingDefaultSeed {
       ...propertySeed,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "/images/dev/Morton Manor.png",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10157.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10157.ts
@@ -80,12 +80,7 @@ export class Listing10157Seed extends ListingDefaultSeed {
       ...nccProperty,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "https://ginosko.com/wp-content/uploads/2018/06/ncc-2.jpg",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10158.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10158.ts
@@ -73,12 +73,7 @@ export class Listing10158Seed extends ListingDefaultSeed {
       ...ncpProperty,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "/images/dev/New Center Pavilion.png",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10159.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10159.ts
@@ -72,13 +72,7 @@ export class Listing10159Seed extends ListingDefaultSeed {
       ...propertySeed,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId:
-          "https://rentpath-res.cloudinary.com/t_rp,cs_tinysrgb,fl_force_strip,w_400,h_240,c_fill,q_auto:low,dpr_1.0/e_unsharp_mask:50/ed25c8ac2a650c47de36884830f2cf2d",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10168.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10168.ts
@@ -75,13 +75,7 @@ export class Listing10168Seed extends ListingDefaultSeed {
         "https://voa-production.s3.amazonaws.com/uploads/pdf_file/file/1118/Oak_Village_Independence_House_Resident_Selection_Guidelines.pdf",
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId:
-          "https://voa-production.s3.amazonaws.com/uploads/housing_property_image/image/1290/DSC_0881.jpg",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const unitTypeOneBdrm = await this.unitTypeRepository.findOneOrFail({ name: "oneBdrm" })
 

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10169.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10169.ts
@@ -83,13 +83,7 @@ export class Listing10157Seed extends ListingDefaultSeed {
       ...grandRivProperty,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId:
-          "https://cdngeneralcf.rentcafe.com/dmslivecafe/3/601734/01_Home_Hero_28G.jpg?quality=85&scale=both&",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10202.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10202.ts
@@ -72,12 +72,7 @@ export class Listing10202Seed extends ListingDefaultSeed {
       ...mcvProperty,
     })
 
-    const assets: Array<AssetDtoSeedType> = [
-      {
-        label: "building",
-        fileId: "https://s3.amazonaws.com/photos.rentlinx.com/L800/85883803.jpg",
-      },
-    ]
+    const assets: Array<AssetDtoSeedType> = []
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -15,7 +15,6 @@ import { setMinMax } from "./unit-transformation-helpers"
 // One row for every unit group, with rent and ami ranges across all ami levels
 // Used to display the main pricing table
 export const getUnitGroupSummary = (unitGroups: UnitGroup[] = []): UnitGroupSummary[] => {
-  console.log("unitGroups = ", unitGroups)
   const summary: UnitGroupSummary[] = []
 
   const sortedUnitGroups = unitGroups?.sort(

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -12,15 +12,10 @@ import { MonthlyRentDeterminationType } from "../units-summary/types/monthly-ren
 import { HUDMSHDA2021 } from "../seeder/seeds/ami-charts/HUD-MSHDA2021"
 import { setMinMax } from "./unit-transformation-helpers"
 
-// One row for every unit group with occupancy / sq ft / floor range averaged across all unit types
-// Used to display the occupancy table, unit type accordions
-export const getUnitTypeSummary = (unitGroups: UnitGroup[]): UnitTypeSummary[] => {
-  return []
-}
-
 // One row for every unit group, with rent and ami ranges across all ami levels
 // Used to display the main pricing table
 export const getUnitGroupSummary = (unitGroups: UnitGroup[] = []): UnitGroupSummary[] => {
+  console.log("unitGroups = ", unitGroups)
   const summary: UnitGroupSummary[] = []
 
   const sortedUnitGroups = unitGroups?.sort(
@@ -163,7 +158,6 @@ export const summarizeUnits = (units: UnitGroup[], amiCharts: AmiChart[]): UnitS
     return data
   }
 
-  data.unitTypeSummary = getUnitTypeSummary(units)
   data.unitGroupSummary = getUnitGroupSummary(units)
   data.householdMaxIncomeSummary = getHouseholdMaxIncomeSummary(units, amiCharts)
   return data

--- a/backend/core/src/units-summary/dto/unit-group.dto.ts
+++ b/backend/core/src/units-summary/dto/unit-group.dto.ts
@@ -32,6 +32,7 @@ export class UnitGroupCreateDto extends OmitType(UnitGroupDto, [
   "id",
   "unitType",
   "amiLevels",
+  "listingId",
 ] as const) {
   @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/units-summary/entities/unit-group.entity.ts
+++ b/backend/core/src/units-summary/entities/unit-group.entity.ts
@@ -45,9 +45,8 @@ export class UnitGroup {
 
   @RelationId((unitGroupEntity: UnitGroup) => unitGroupEntity.listing)
   @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
-  listingId?: string | null
+  listingId: string
 
   @OneToMany(() => UnitGroupAmiLevel, (UnitGroupAmiLevel) => UnitGroupAmiLevel.unitGroup, {
     eager: true,

--- a/backend/core/src/units-summary/entities/unit-group.entity.ts
+++ b/backend/core/src/units-summary/entities/unit-group.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  RelationId,
 } from "typeorm"
 import {
   IsBoolean,
@@ -41,6 +42,12 @@ export class UnitGroup {
 
   @ManyToOne(() => Listing, (listing) => listing.unitGroups, {})
   listing: Listing
+
+  @RelationId((unitGroupEntity: UnitGroup) => unitGroupEntity.listing)
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  listingId?: string | null
 
   @OneToMany(() => UnitGroupAmiLevel, (UnitGroupAmiLevel) => UnitGroupAmiLevel.unitGroup, {
     eager: true,

--- a/backend/core/src/units/types/unit-summaries.ts
+++ b/backend/core/src/units/types/unit-summaries.ts
@@ -2,7 +2,6 @@ import { Expose, Type } from "class-transformer"
 import { IsDefined, ValidateNested } from "class-validator"
 import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enum"
 import { UnitGroupSummary } from "./unit-group-summary"
-import { UnitTypeSummary } from "./unit-type-summary"
 import { HouseholdMaxIncomeSummary } from "./household-max-income-summary"
 import { ApiProperty } from "@nestjs/swagger"
 
@@ -13,13 +12,6 @@ export class UnitSummaries {
   @Type(() => UnitGroupSummary)
   @ApiProperty({ type: [UnitGroupSummary] })
   unitGroupSummary: UnitGroupSummary[]
-
-  @Expose()
-  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
-  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
-  @Type(() => UnitTypeSummary)
-  @ApiProperty({ type: [UnitTypeSummary] })
-  unitTypeSummary: UnitTypeSummary[]
 
   @Expose()
   @ApiProperty({ type: HouseholdMaxIncomeSummary })

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4457,7 +4457,7 @@ export interface UnitGroup {
   id: string
 
   /**  */
-  listingId?: string
+  listingId: string
 
   /**  */
   maxOccupancy?: number
@@ -5441,9 +5441,6 @@ export interface UnitGroupCreate {
   amiLevels: UnitGroupAmiLevelCreate[]
 
   /**  */
-  listingId?: string
-
-  /**  */
   maxOccupancy?: number
 
   /**  */
@@ -5914,9 +5911,6 @@ export interface UnitGroupUpdate {
 
   /**  */
   amiLevels: UnitGroupAmiLevelUpdate[]
-
-  /**  */
-  listingId?: string
 
   /**  */
   maxOccupancy?: number

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -3973,23 +3973,6 @@ export interface UnitGroupSummary {
   bathroomRange?: MinMax
 }
 
-export interface UnitTypeSummary {
-  /**  */
-  unitTypes: string[]
-
-  /**  */
-  occupancyRange: MinMax
-
-  /**  */
-  areaRange: MinMax
-
-  /**  */
-  floorRange?: MinMax
-
-  /**  */
-  bathroomRange?: MinMax
-}
-
 export interface HMIColumns {
   /**  */
   "20"?: number
@@ -4054,9 +4037,6 @@ export interface HouseholdMaxIncomeSummary {
 export interface UnitSummaries {
   /**  */
   unitGroupSummary: UnitGroupSummary[]
-
-  /**  */
-  unitTypeSummary: UnitTypeSummary[]
 
   /**  */
   householdMaxIncomeSummary: HouseholdMaxIncomeSummary
@@ -4475,6 +4455,9 @@ export interface UnitGroup {
 
   /**  */
   id: string
+
+  /**  */
+  listingId?: string
 
   /**  */
   maxOccupancy?: number
@@ -5458,6 +5441,9 @@ export interface UnitGroupCreate {
   amiLevels: UnitGroupAmiLevelCreate[]
 
   /**  */
+  listingId?: string
+
+  /**  */
   maxOccupancy?: number
 
   /**  */
@@ -5928,6 +5914,9 @@ export interface UnitGroupUpdate {
 
   /**  */
   amiLevels: UnitGroupAmiLevelUpdate[]
+
+  /**  */
+  listingId?: string
 
   /**  */
   maxOccupancy?: number

--- a/sites/partners/lib/helpers.ts
+++ b/sites/partners/lib/helpers.ts
@@ -15,7 +15,7 @@ import {
   ListingEvent,
   IncomePeriod,
 } from "@bloom-housing/backend-core/types"
-import { TempUnit, FormListing, TempUnitsSummary } from "../src/listings/PaperListingForm/formTypes"
+import { TempUnit, FormListing } from "../src/listings/PaperListingForm/formTypes"
 import { FieldError } from "react-hook-form"
 
 type DateTimePST = {

--- a/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitsSummaryForm.tsx
@@ -24,10 +24,9 @@ import {
   MonthlyRentDeterminationType,
   UnitAccessibilityPriorityType,
 } from "@bloom-housing/backend-core/types"
-import { useUnitPriorityList } from "../../../lib/hooks"
+import { useUnitPriorityList, useAmiChartList } from "../../../lib/hooks"
 import { arrayToFormOptions } from "../../../lib/helpers"
 import UnitsSummaryAmiForm from "./UnitsSummaryAmiForm"
-import { useAmiChartList } from "../../../lib/hooks"
 
 interface FieldSingle {
   id: string

--- a/sites/partners/src/listings/PaperListingForm/formTypes.ts
+++ b/sites/partners/src/listings/PaperListingForm/formTypes.ts
@@ -18,7 +18,7 @@ export enum AnotherAddressEnum {
   anotherAddress = "anotherAddress",
 }
 
-export type FormListing = Omit<Listing, "countyCode" | "unitSummaries"> & {
+export type FormListing = Omit<Listing, "countyCode" | "unitSummaries" | "unitGroups"> & {
   applicationDueDateField?: {
     month: string
     day: string
@@ -180,7 +180,11 @@ export type TempAmiLevel = UnitGroupAmiLevel & {
   tempId?: number
 }
 
-export interface TempUnitsSummary extends UnitGroup {
+export type UnitGroupType = Omit<UnitGroup, "listingId"> & {
+  listingId?: string
+}
+
+export interface TempUnitsSummary extends UnitGroupType {
   tempId?: number
   amiLevels: TempAmiLevel[]
   openWaitListQuestion?: string
@@ -199,6 +203,6 @@ export type FormMetadata = {
   profile: User
   latLong: LatitudeLongitude
   customMapPositionChosen: boolean
-  unitGroups: UnitGroup[]
+  unitGroups: UnitGroupType[]
   programs: Program[]
 }

--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -6,6 +6,7 @@ import { ConfirmationModal } from "../src/ConfirmationModal"
 import { MetaTags } from "../src/MetaTags"
 import { HorizontalScrollSection } from "../lib/HorizontalScrollSection"
 import axios from "axios"
+import qs from "qs"
 import styles from "./index.module.scss"
 import {
   EnumListingFilterParamsComparison,
@@ -135,6 +136,9 @@ export async function getStaticProps() {
             status: EnumListingFilterParamsStatus.active,
           },
         ],
+      },
+      paramsSerializer: (params) => {
+        return qs.stringify(params)
       },
     })
     latestListings = response.data


### PR DESCRIPTION
## Issue

- Addresses #1059 in part

## Description

This adds unit summaries to the listings list for use on the frontend browse and filtered pages.

## How Can This Be Tested/Reviewed?

Reseed the db locally and see that unitSummaries are on the listings.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
