### PR TITLE
fix: show not available for blank unit summary cells

### DIFF
--- a/sites/public/lib/helpers.tsx
+++ b/sites/public/lib/helpers.tsx
@@ -216,9 +216,9 @@ export const getUnitGroupSummary = (listing: Listing): UnitSummaryTable => {
             .reduce((acc, curr) => [acc, ", ", curr])}
         </>
       ),
-      rent,
-      availability,
-      ami: <strong>{ami}</strong>,
+      rent: rent ?? t("listings.unitsSummary.notAvailable"),
+      availability: availability ?? t("listings.unitsSummary.notAvailable"),
+      ami: ami ?? t("listings.unitsSummary.notAvailable"),
     }
   })
 

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1506,6 +1506,7 @@
       "sqFeetMin": "Minimum Square Footage",
       "sqFeetMax": "Max Square Footage",
       "availability": "Availability",
+      "notAvailable": "Not available",
       "count": "Afforable Unit Group Quantity",
       "available": "Total Available",
       "delete": "Delete this Summary",


### PR DESCRIPTION
## Issue

- Closes #1098 

## Description

Shows `Not available` instead of a blank cell for cells in the unit summary tables that have no information.

## How Can This Be Tested/Reviewed?

Look at the directory page and detail page tables, and ensure there are no empty cells and the new string is in its place. The unit type is a required field, so I didn't add that logic there.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
