### PR TITLE
feat: default what to expect text and additional what to expect field

### DIFF
--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -422,6 +422,12 @@ class Listing extends BaseEntity {
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   whatToExpect?: string | null
 
+  @Column({ type: "text", nullable: true })
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  whatToExpectAdditionalText?: string | null
+
   @Column({
     type: "enum",
     enum: ListingStatus,

--- a/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
+++ b/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
@@ -4,7 +4,9 @@ export class addWhatToExpectAdditionalText1649893064530 implements MigrationInte
   name = "addWhatToExpectAdditionalText1649893064530"
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const detroitJurisdiction = await queryRunner.query(
+    await queryRunner.query(`ALTER TABLE "listings" ADD "what_to_expect_additional_text" text`)
+
+    const [{ id: detroitJurisdiction }] = await queryRunner.query(
       `SELECT id FROM jurisdictions WHERE name = 'Detroit'`
     )
 
@@ -19,11 +21,11 @@ export class addWhatToExpectAdditionalText1649893064530 implements MigrationInte
     for (const listing of detroitListings) {
       await queryRunner.query(`UPDATE listings SET what_to_expect = ($1) WHERE id = ($2)`, [
         defaultWhatToExpect,
-        listing.id,
+        listing["id"],
       ])
       await queryRunner.query(
         `UPDATE listings SET what_to_expect_additional_text = ($1) WHERE id = ($2)`,
-        [defaultWhatToExpectAdditionalText, listing.id]
+        [defaultWhatToExpectAdditionalText, listing["id"]]
       )
     }
   }

--- a/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
+++ b/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class addWhatToExpectAdditionalText1649893064530 implements MigrationInterface {
+  name = "addWhatToExpectAdditionalText1649893064530"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const detroitJurisdiction = await queryRunner.query(
+      `SELECT id FROM jurisdictions WHERE name = 'Detroit'`
+    )
+
+    const detroitListings = await queryRunner.query(
+      `SELECT id from listings where jurisdiction_id = ($1)`,
+      [detroitJurisdiction]
+    )
+
+    const defaultWhatToExpect = `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`
+    const defaultWhatToExpectAdditionalText = `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`
+
+    for (const listing of detroitListings) {
+      await queryRunner.query(`UPDATE listings SET what_to_expect = ($1) WHERE id = ($2)`, [
+        defaultWhatToExpect,
+        listing.id,
+      ])
+      await queryRunner.query(
+        `UPDATE listings SET what_to_expect_additional_text = ($1) WHERE id = ($2)`,
+        [defaultWhatToExpectAdditionalText, listing.id]
+      )
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "listings" DROP COLUMN "what_to_expect_additional_text"`)
+  }
+}

--- a/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
+++ b/backend/core/src/migration/1649893064530-add-what-to-expect-additional-text.ts
@@ -4,30 +4,14 @@ export class addWhatToExpectAdditionalText1649893064530 implements MigrationInte
   name = "addWhatToExpectAdditionalText1649893064530"
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "listings" ADD "what_to_expect_additional_text" text`)
-
-    const [{ id: detroitJurisdiction }] = await queryRunner.query(
-      `SELECT id FROM jurisdictions WHERE name = 'Detroit'`
-    )
-
-    const detroitListings = await queryRunner.query(
-      `SELECT id from listings where jurisdiction_id = ($1)`,
-      [detroitJurisdiction]
-    )
-
     const defaultWhatToExpect = `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`
     const defaultWhatToExpectAdditionalText = `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`
+    await queryRunner.query(`ALTER TABLE "listings" ADD "what_to_expect_additional_text" text`)
 
-    for (const listing of detroitListings) {
-      await queryRunner.query(`UPDATE listings SET what_to_expect = ($1) WHERE id = ($2)`, [
-        defaultWhatToExpect,
-        listing["id"],
-      ])
-      await queryRunner.query(
-        `UPDATE listings SET what_to_expect_additional_text = ($1) WHERE id = ($2)`,
-        [defaultWhatToExpectAdditionalText, listing["id"]]
-      )
-    }
+    await queryRunner.query(`UPDATE listings SET what_to_expect = ($1)`, [defaultWhatToExpect])
+    await queryRunner.query(`UPDATE listings SET what_to_expect_additional_text = ($1)`, [
+      defaultWhatToExpectAdditionalText,
+    ])
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10136.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10136.ts
@@ -64,6 +64,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10136Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10145.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10145.ts
@@ -62,6 +62,8 @@ const mcvListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10145Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10147.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10147.ts
@@ -60,6 +60,8 @@ const mshListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10147Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10151.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10151.ts
@@ -62,6 +62,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10151Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10153.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10153.ts
@@ -61,6 +61,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10153Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10154.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10154.ts
@@ -62,6 +62,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10154Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10155.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10155.ts
@@ -61,6 +61,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.ComingSoon,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10155Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10157.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10157.ts
@@ -70,6 +70,8 @@ const nccListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10157Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10158.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10158.ts
@@ -64,6 +64,8 @@ const ncpListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10158Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10159.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10159.ts
@@ -64,6 +64,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10159Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10168.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10168.ts
@@ -66,6 +66,8 @@ const listingSeed: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10168Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10169.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10169.ts
@@ -73,6 +73,8 @@ const grandRivListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10157Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-10202.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-10202.ts
@@ -63,6 +63,8 @@ const mcvListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class Listing10202Seed extends ListingDefaultSeed {

--- a/backend/core/src/seeder/seeds/listings/listing-detroit-treymore.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-detroit-treymore.ts
@@ -1,4 +1,4 @@
-import { AssetDtoSeedType, ListingSeedType, PropertySeedType } from "./listings"
+import { ListingSeedType, PropertySeedType } from "./listings"
 import { ListingStatus } from "../../../listings/types/listing-status-enum"
 import { CountyCode } from "../../../shared/types/county-code"
 import { ListingDefaultSeed } from "./listing-default-seed"
@@ -67,6 +67,8 @@ const treymoreListing: ListingSeedType = {
   listingPreferences: [],
   jurisdictionName: "Detroit",
   marketingType: ListingMarketingTypeEnum.Marketing,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
 }
 
 export class ListingTreymoreSeed extends ListingDefaultSeed {

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -5491,6 +5491,9 @@ export interface Listing {
   whatToExpect?: string
 
   /**  */
+  whatToExpectAdditionalText?: string
+
+  /**  */
   applicationConfig?: object
 
   /**  */
@@ -5956,6 +5959,9 @@ export interface ListingCreate {
 
   /**  */
   whatToExpect?: string
+
+  /**  */
+  whatToExpectAdditionalText?: string
 
   /**  */
   applicationConfig?: object
@@ -6433,6 +6439,9 @@ export interface ListingUpdate {
 
   /**  */
   whatToExpect?: string
+
+  /**  */
+  whatToExpectAdditionalText?: string
 
   /**  */
   applicationConfig?: object

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -283,6 +283,7 @@
   "listings.waitlist.openSize": "Number of Openings",
   "listings.waitlist.openSizeQuestion": "How many spots are open on the list?",
   "listings.whatToExpectLabel": "Tell the applicant what to expect from the process",
+  "listings.whatToExpectAdditionalTextLabel": "Tell the applicant additional information about what to expect from the process",
   "listings.whenApplicationsClose": "When applications close to the public",
   "listings.whereDropOffQuestion": "Where are applications dropped off?",
   "listings.wherePickupQuestion": "Where are applications picked up?",

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -85,6 +85,13 @@ const DetailRankingsAndResults = () => {
           </ViewItem>
         </GridCell>
       </GridSection>
+      <GridSection columns={1}>
+        <GridCell>
+          <ViewItem id="whatToExpect" label={t("listings.whatToExpectAdditionalTextLabel")}>
+            {getDetailFieldString(listing.whatToExpectAdditionalText)}
+          </ViewItem>
+        </GridCell>
+      </GridSection>
     </GridSection>
   )
 }

--- a/sites/partners/src/listings/PaperListingForm/formTypes.ts
+++ b/sites/partners/src/listings/PaperListingForm/formTypes.ts
@@ -143,8 +143,8 @@ export const formDefaults: FormListing = {
   waitlistMaxSize: null,
   isWaitlistOpen: null,
   waitlistOpenSpots: null,
-  whatToExpect:
-    "Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.",
+  whatToExpectAdditionalText: `<ul className="list-disc pl-6"><li>Property staff should walk you through the process to get on their waitlist.</li><li>You can be on waitlists for multiple properties, but you will need to contact each one of them to begin that process.</li><li>Even if you are on a waitlist, it can take months or over a year to get an available unit for that building.</li><li>Many properties that are affordable because of government funding or agreements have long waitlists. If you're on a waitlist for a property, you will be notified as available units come up.</li></ul>`,
+  whatToExpect: `<div><strong>Vacant Units</strong>:<div className="mb-3">If you are looking to move in immediately, contact the property and ask if they have any vacant units.</div><div><strong>Waitlists</strong>:<div>If none are vacant, but you are still interested in living at the property in the future, ask how you can be placed on their waitlist.</div>`,
   units: [],
   accessibility: "",
   amenities: "",

--- a/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -269,6 +269,17 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
             />
           </GridCell>
         </GridSection>
+        <GridSection columns={3}>
+          <GridCell span={2}>
+            <Textarea
+              label={t("listings.whatToExpectAdditionalTextLabel")}
+              name={"whatToExpectAdditionalText"}
+              id={"whatToExpectAdditionalText"}
+              fullWidth={true}
+              register={register}
+            />
+          </GridCell>
+        </GridSection>
       </GridSection>
     </div>
   )

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -20,18 +20,19 @@ import {
   ImageCard,
   InfoCard,
   LeasingAgent,
+  ListSection,
   ListingDetailItem,
   ListingDetails,
   ListingMap,
   ListingUpdated,
-  ListSection,
   OneLineAddress,
   OpenHouseEvent,
   ReferralApplication,
   StandardTable,
   SubmitApplication,
-  t,
   Waitlist,
+  WhatToExpect,
+  t,
 } from "@bloom-housing/ui-components"
 import {
   cloudinaryPdfFromId,
@@ -75,7 +76,7 @@ export const ListingProcess = (props: ListingProcessProps) => {
   } = props
 
   return (
-    <aside className="w-full static md:mr-8 md:ml-2 md:border border-gray-400 bg-white">
+    <aside className="w-full static md:mr-8 md:ml-2 md:border border-gray-400 bg-white text-gray-750">
       <ListingUpdated listingUpdated={listing.updatedAt} />
       {openHouseEvents && <OpenHouseEvent events={openHouseEvents} />}
       {!applicationsClosed && (
@@ -105,6 +106,10 @@ export const ListingProcess = (props: ListingProcessProps) => {
           <OpenHouseEvent events={openHouseEvents} />
         </div>
       )}
+      <WhatToExpect
+        content={listing.whatToExpect}
+        expandableContent={listing.whatToExpectAdditionalText}
+      />
       <LeasingAgent
         listing={listing}
         managementCompany={{

--- a/ui-components/__tests__/page_components/WhatToExpect.test.tsx
+++ b/ui-components/__tests__/page_components/WhatToExpect.test.tsx
@@ -1,23 +1,20 @@
 import React from "react"
-import { render, cleanup } from "@testing-library/react"
+import { render, cleanup, fireEvent } from "@testing-library/react"
 import { WhatToExpect } from "../../src/page_components/listing/listing_sidebar/WhatToExpect"
-import Archer from "../fixtures/archer.json"
-import { t } from "../../src/helpers/translator"
-
-const archer = Object.assign({}, Archer) as any
 
 afterEach(cleanup)
 
 describe("<WhatToExpect>", () => {
-  it("renders with default what-to-expects", () => {
-    const { getByText } = render(<WhatToExpect listing={archer} />)
-    expect(getByText(t("whatToExpect.default"))).toBeTruthy()
-  })
-  it("renders with custom what-to-expects", () => {
-    const newListing = archer
-    newListing.whatToExpect = "Custom what to expect text"
-
-    const { getByText } = render(<WhatToExpect listing={archer} />)
-    expect(getByText("Custom what to expect text")).toBeTruthy()
+  it("renders expected text and expandable content", () => {
+    const { getByText, queryByText } = render(
+      <WhatToExpect
+        content={"What To Expect Content"}
+        expandableContent={"What To Expect Expandable Content"}
+      />
+    )
+    expect(getByText("What To Expect Content")).toBeTruthy()
+    expect(queryByText("What To Expect Expandable Content")).toBeFalsy()
+    fireEvent.click(getByText("read more"))
+    expect(getByText("What To Expect Expandable Content")).toBeTruthy()
   })
 })

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -26,9 +26,9 @@ const LeasingAgent = (props: LeasingAgentProps) => {
       <h4 className="text-caps-underline">{t("leasingAgent.contact")}</h4>
 
       {listing.leasingAgentName && <p className="text-xl">{listing.leasingAgentName}</p>}
-      {listing.leasingAgentTitle && <p className="text-gray-700">{listing.leasingAgentTitle}</p>}
+      {listing.leasingAgentTitle && <p className="text-gray-750">{listing.leasingAgentTitle}</p>}
       {props.managementCompany?.name && (
-        <p className="text-gray-700">{props.managementCompany.name}</p>
+        <p className="text-gray-750">{props.managementCompany.name}</p>
       )}
 
       {listing.leasingAgentPhone && (
@@ -39,7 +39,7 @@ const LeasingAgent = (props: LeasingAgentProps) => {
               {listing.leasingAgentPhone}
             </a>
           </p>
-          <p className="text-sm text-gray-700">{t("leasingAgent.dueToHighCallVolume")}</p>
+          <p className="text-sm text-gray-750">{t("leasingAgent.dueToHighCallVolume")}</p>
         </>
       )}
 

--- a/ui-components/src/page_components/listing/listing_sidebar/ListingUpdated.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/ListingUpdated.tsx
@@ -10,7 +10,7 @@ const ListingUpdated = (props: ListingUpdatedProps) => {
   const listingUpdated = props.listingUpdated
   return (
     <section className="aside-block">
-      <p className="text-tiny text-gray-800">
+      <p className="text-tiny text-gray-750">
         {`${t("listings.listingUpdated")}: ${dayjs(listingUpdated).format("MMMM DD, YYYY")}`}
       </p>
     </section>

--- a/ui-components/src/page_components/listing/listing_sidebar/ReferralApplication.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/ReferralApplication.tsx
@@ -20,7 +20,7 @@ const ReferralApplication = (props: ReferralApplicationProps) => {
           {props.phoneNumber}
         </a>
       </p>
-      <p className="text-tiny mt-4 text-gray-800">{props.description}</p>
+      <p className="text-tiny mt-4 text-gray-750">{props.description}</p>
     </section>
   )
 }

--- a/ui-components/src/page_components/listing/listing_sidebar/SidebarAddress.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/SidebarAddress.tsx
@@ -28,7 +28,7 @@ const SidebarAddress = (props: SidebarAddressProps) => {
     hours = (
       <>
         <h3 className="text-caps-tiny ">{t("leasingAgent.officeHours")}</h3>
-        <div className="text-gray-800 text-tiny markdown">
+        <div className="text-gray-750 text-tiny markdown">
           <Markdown children={officeHours} options={{ disableParsingRawHTML: true }} />
         </div>
       </>

--- a/ui-components/src/page_components/listing/listing_sidebar/Waitlist.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/Waitlist.tsx
@@ -9,7 +9,7 @@ export interface WaitlistProps {
 }
 
 const WaitlistItem = (props: { className?: string; value: number; text: string }) => (
-  <li className={`uppercase text-gray-800 text-tiny ${props.className}`}>
+  <li className={`uppercase text-gray-750 text-tiny ${props.className}`}>
     <span className="text-right w-12 inline-block pr-2">{props.value}</span>
     <span>{props.text}</span>
   </li>
@@ -22,7 +22,7 @@ const Waitlist = (props: WaitlistProps) => {
     <section className="aside-block is-tinted">
       <h4 className="text-caps-tiny">{t("listings.waitlist.unitsAndWaitlist")}</h4>
       <div>
-        <p className="text-tiny text-gray-800 pb-3">{t("listings.waitlist.submitAnApplication")}</p>
+        <p className="text-tiny text-gray-750 pb-3">{t("listings.waitlist.submitAnApplication")}</p>
         <ul>
           {props.waitlistCurrentSize !== null && props.waitlistCurrentSize !== undefined && (
             <WaitlistItem

--- a/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
-import { t } from "../../../helpers/translator"
 import { Listing } from "@bloom-housing/backend-core/types"
+import Markdown from "markdown-to-jsx"
+import { t } from "../../../helpers/translator"
+import { ExpandableContent } from "../../../actions/ExpandableContent"
 
 interface WhatToExpectProps {
   listing: Listing
@@ -8,13 +10,22 @@ interface WhatToExpectProps {
 
 const WhatToExpect = (props: WhatToExpectProps) => {
   const listing = props.listing
-
+  if (!listing.whatToExpect || listing.whatToExpect === "") return null
   return (
     <section className="aside-block">
       <h4 className="text-caps-underline">{t("whatToExpect.label")}</h4>
-      <p className="text-tiny text-gray-800">
-        {listing.whatToExpect ? listing.whatToExpect : t("whatToExpect.default")}
-      </p>
+      <div className="text-tiny text-gray-750">
+        <Markdown options={{ disableParsingRawHTML: false }}>{listing.whatToExpect ?? ""}</Markdown>
+        {listing.whatToExpectAdditionalText && (
+          <div className={"mt-2"}>
+            <ExpandableContent>
+              <Markdown options={{ disableParsingRawHTML: false }}>
+                {listing.whatToExpectAdditionalText}
+              </Markdown>
+            </ExpandableContent>
+          </div>
+        )}
+      </div>
     </section>
   )
 }

--- a/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
@@ -9,7 +9,7 @@ interface WhatToExpectProps {
 }
 
 const WhatToExpect = ({ content, expandableContent }: WhatToExpectProps) => {
-  if (!content || content === "") return null
+  if (!content) return null
   return (
     <section className="aside-block">
       <h4 className="text-caps-underline">{t("whatToExpect.label")}</h4>

--- a/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
@@ -1,27 +1,24 @@
 import * as React from "react"
-import { Listing } from "@bloom-housing/backend-core/types"
 import Markdown from "markdown-to-jsx"
 import { t } from "../../../helpers/translator"
 import { ExpandableContent } from "../../../actions/ExpandableContent"
 
 interface WhatToExpectProps {
-  listing: Listing
+  content: string
+  expandableContent: string
 }
 
-const WhatToExpect = (props: WhatToExpectProps) => {
-  const listing = props.listing
-  if (!listing.whatToExpect || listing.whatToExpect === "") return null
+const WhatToExpect = ({ content, expandableContent }: WhatToExpectProps) => {
+  if (!content || content === "") return null
   return (
     <section className="aside-block">
       <h4 className="text-caps-underline">{t("whatToExpect.label")}</h4>
       <div className="text-tiny text-gray-750">
-        <Markdown options={{ disableParsingRawHTML: false }}>{listing.whatToExpect ?? ""}</Markdown>
-        {listing.whatToExpectAdditionalText && (
+        <Markdown options={{ disableParsingRawHTML: false }}>{content}</Markdown>
+        {expandableContent && (
           <div className={"mt-2"}>
             <ExpandableContent>
-              <Markdown options={{ disableParsingRawHTML: false }}>
-                {listing.whatToExpectAdditionalText}
-              </Markdown>
+              <Markdown options={{ disableParsingRawHTML: false }}>{expandableContent}</Markdown>
             </ExpandableContent>
           </div>
         )}

--- a/ui-components/src/page_components/listing/listing_sidebar/events/DownloadLotteryResults.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/DownloadLotteryResults.tsx
@@ -13,7 +13,7 @@ const DownloadLotteryResults = (props: DownloadLotteryResultsProps) => {
     <section className="aside-block text-center">
       <h2 className="text-caps pb-4">{t("listings.lotteryResults.header")}</h2>
       {props.resultsDate && (
-        <p className="uppercase text-gray-800 text-tiny font-semibold pb-4">{props.resultsDate}</p>
+        <p className="uppercase text-gray-750 text-tiny font-semibold pb-4">{props.resultsDate}</p>
       )}
       <a
         className="button is-primary w-full mb-2"

--- a/ui-components/src/page_components/listing/listing_sidebar/events/EventDateSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/EventDateSection.tsx
@@ -11,7 +11,7 @@ const EventDateSection = (props: { event: ListingEvent }) => {
   return (
     <>
       {props.event.startTime && (
-        <p className="text text-gray-800 pb-3 flex justify-between items-center">
+        <p className="text text-gray-750 pb-3 flex justify-between items-center">
           <span className="inline-block text-tiny uppercase">
             {dayjs(props.event.startTime).format("MMMM D, YYYY")}
           </span>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/LotteryResultsEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/LotteryResultsEvent.tsx
@@ -8,7 +8,7 @@ const LotteryResultsEvent = (props: { event: ListingEvent }) => {
   return (
     <section className="aside-block">
       <h4 className="text-caps-underline">{t("listings.lotteryResults.header")}</h4>
-      <p className="text text-gray-800 pb-3 flex justify-between items-center">
+      <p className="text text-gray-750 pb-3 flex justify-between items-center">
         <span className="inline-block">{dayjs(props.event.startTime).format("MMMM D, YYYY")}</span>
       </p>
       {event.note && <p className="text text-gray-600">{event.note}</p>}

--- a/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
@@ -11,7 +11,7 @@ const OpenHouseEvent = (props: { events: ListingEvent[] }) => {
         <div key={`openHouses-${index}`}>
           <EventDateSection event={openHouseEvent} />
           {openHouseEvent.url && (
-            <p className="text text-gray-807500 pb-3">
+            <p className="text text-gray-750 pb-3">
               <a href={openHouseEvent.url}>
                 {openHouseEvent.label || t("listings.openHouseEvent.seeVideo")}
               </a>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
@@ -11,7 +11,7 @@ const OpenHouseEvent = (props: { events: ListingEvent[] }) => {
         <div key={`openHouses-${index}`}>
           <EventDateSection event={openHouseEvent} />
           {openHouseEvent.url && (
-            <p className="text text-gray-800 pb-3">
+            <p className="text text-gray-807500 pb-3">
               <a href={openHouseEvent.url}>
                 {openHouseEvent.label || t("listings.openHouseEvent.seeVideo")}
               </a>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/PublicLotteryEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/PublicLotteryEvent.tsx
@@ -10,7 +10,7 @@ const PublicLotteryEvent = (props: { event: ListingEvent }) => {
       <h4 className="text-caps-underline">{t("listings.publicLottery.header")}</h4>
       <EventDateSection event={props.event} />
       {event.url && (
-        <p className="text text-gray-800 pb-3">
+        <p className="text text-gray-750 pb-3">
           <a href={event.url}>{t("listings.publicLottery.seeVideo")}</a>
         </p>
       )}


### PR DESCRIPTION
## Issue

- Closes #1054

## Description

Add a new `whatToExpect` text default, and the ability to add a read more section to the what to expect text which lives in the new `whatToExpectAdditionalText` field.

## How Can This Be Tested/Reviewed?

Ensure the default is set on new listings and that existing listings all have their what to expect and additional information fields set to the defaults.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
