### PR TITLE
feat: disable mfa for Detroit

### DIFF
--- a/backend/core/src/auth/services/user.service.ts
+++ b/backend/core/src/auth/services/user.service.ts
@@ -475,6 +475,7 @@ export class UserService {
           ? (dto.jurisdictions as Jurisdiction[])
           : [await this.jurisdictionService.findOne({ where: { name: "Detroit" } })],
         preferences: (dto.preferences as unknown) as UserPreferences,
+        mfaEnabled: false,
       },
       authContext
     )

--- a/backend/core/src/migration/1639051722043-add-mfa-related-columns-to-user-entity.ts
+++ b/backend/core/src/migration/1639051722043-add-mfa-related-columns-to-user-entity.ts
@@ -10,7 +10,7 @@ export class addMfaRelatedColumnsToUserEntity1639051722043 implements MigrationI
     await queryRunner.query(`ALTER TABLE "user_accounts" ADD "mfa_code" character varying`)
     await queryRunner.query(`
         UPDATE user_accounts
-        SET mfa_enabled = true
+        SET mfa_enabled = false
         WHERE id IN
             (SELECT id
              FROM user_accounts

--- a/backend/core/src/seeder/seed.ts
+++ b/backend/core/src/seeder/seed.ts
@@ -382,7 +382,7 @@ async function seed() {
   await userRepo.save(admin)
   await userRepo.save({
     ...mfaUser,
-    mfaEnabled: true,
+    mfaEnabled: false,
     mfaCode: "123456",
     mfaCodeUpdatedAt: dayjs(new Date()).add(1, "day"),
   })


### PR DESCRIPTION
## Description

This sets mfaEnabled to false, which should effectively disable mfa for Detroit.

## How Can This Be Tested/Reviewed?

Locally, reseed and no partners should have mfa enabled. Create a new partner and they shouldn't
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
