### PR TITLE
fix: coming soon tag color on listing detail page

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -44,11 +44,11 @@ import { ErrorPage } from "../pages/_error"
 import {
   getGenericAddress,
   getHmiSummary,
-  getImageTagLabelFromListing,
   getListingTags,
   getUnitGroupSummary,
   openInFuture,
   getListingTag,
+  getImageCardTag,
 } from "../lib/helpers"
 
 interface ListingProps {
@@ -272,17 +272,7 @@ export const ListingView = (props: ListingProps) => {
       <header className="image-card--leader">
         <ImageCard
           imageUrl={imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))}
-          tags={
-            getImageTagLabelFromListing(listing)
-              ? [
-                  {
-                    text: getImageTagLabelFromListing(listing),
-                    iconType: listing?.isVerified ? "badgeCheck" : null,
-                    iconColor: "#193154",
-                  },
-                ]
-              : []
-          }
+          tags={getImageCardTag(listing)}
         />
         <div className="py-3 mx-3">
           <Heading priority={1} style={"cardHeader"}>


### PR DESCRIPTION
## Issue

- Closes #1074

Addresses this piece of QA: https://github.com/CityOfDetroit/bloom/issues/1074#issuecomment-1105548432

## How Can This Be Tested/Reviewed?

The image card tags on the listing detail page should reflect the tags on the directory page. What was missing was the color and icon of the coming soon label.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
