### PR TITLE
feat: add new sign up link to home page

### DIFF
--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -141,6 +141,9 @@ export default function Home({ latestListings }) {
                 href={
                   "https://public.govdelivery.com/accounts/MIDETROIT/subscriber/new?topic_id=MIDETROIT_415"
                 }
+                linkProps={{
+                  target: "_blank",
+                }}
               >
                 {t("welcome.signUpToday")}
               </LinkButton>,

--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -136,7 +136,12 @@ export default function Home({ latestListings }) {
             header={t("welcome.signUp")}
             icon={<Icon size="3xl" symbol="mailThin" />}
             actions={[
-              <LinkButton key={"sign-up"} href={"#"}>
+              <LinkButton
+                key={"sign-up"}
+                href={
+                  "https://public.govdelivery.com/accounts/MIDETROIT/subscriber/new?topic_id=MIDETROIT_415"
+                }
+              >
                 {t("welcome.signUpToday")}
               </LinkButton>,
             ]}

--- a/ui-components/src/actions/LinkButton.tsx
+++ b/ui-components/src/actions/LinkButton.tsx
@@ -7,6 +7,7 @@ import { isExternalLink } from "../helpers/links"
 export interface LinkButtonProps extends Omit<ButtonProps, "onClick"> {
   href: string
   dataTestId?: string
+  linkProps?: Record<string, unknown>
 }
 
 const LinkButton = (props: LinkButtonProps) => {
@@ -15,7 +16,12 @@ const LinkButton = (props: LinkButtonProps) => {
 
   if (isExternalLink(props.href)) {
     return (
-      <a href={props.href} className={buttonClasses.join(" ")} data-test-id={props.dataTestId}>
+      <a
+        href={props.href}
+        className={buttonClasses.join(" ")}
+        data-test-id={props.dataTestId}
+        {...props.linkProps}
+      >
         {buttonInner(props)}
       </a>
     )


### PR DESCRIPTION
## Issue

- Closes #1147

## Description

Adds the new sign-up for notifications link. In core this is pulled off the jurisdictional `notificationsSignUpURL` field, but I'm not clear if we need that here since it's just Detroit? Open to feedback.

## How Can This Be Tested/Reviewed?

Ensure the homepage `Sign Up Today` button goes to the URL in the issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
