### PR TITLE
fix: show street2 for addresses

### DIFF
--- a/ui-components/__tests__/page_components/GetApplication.test.tsx
+++ b/ui-components/__tests__/page_components/GetApplication.test.tsx
@@ -18,7 +18,7 @@ describe("<Applications>", () => {
     expect(getByText("Get a Paper Application")).toBeTruthy()
     expect(getByText("Download Application")).toBeTruthy()
     expect(getByText("Pick up an application")).toBeTruthy()
-    expect(getByText("Pick Up Address Street")).toBeTruthy()
+    expect(getByText("Pick Up Address Street", { exact: false })).toBeTruthy()
     expect(getByText("Office Hours")).toBeTruthy()
   })
   it("disables buttons in preview state", () => {

--- a/ui-components/__tests__/page_components/SubmitApplication.test.tsx
+++ b/ui-components/__tests__/page_components/SubmitApplication.test.tsx
@@ -16,7 +16,7 @@ describe("<ApplicationAddresses>", () => {
     const { getByText } = render(<AllFields />)
     expect(getByText("Submit a Paper Application")).toBeTruthy()
     expect(getByText("Send Application by US Mail")).toBeTruthy()
-    expect(getByText("Mailing Address Street")).toBeTruthy()
+    expect(getByText("Mailing Address Street", { exact: false })).toBeTruthy()
     expect(
       getByText(
         "Applications must be received by the deadline. If sending by U.S. Mail, the application must be postmarked by November 29th, 2021",
@@ -25,7 +25,7 @@ describe("<ApplicationAddresses>", () => {
     ).toBeTruthy()
     expect(getByText("or")).toBeTruthy()
     expect(getByText("Drop Off Application")).toBeTruthy()
-    expect(getByText("Drop Off Address Street")).toBeTruthy()
+    expect(getByText("Drop Off Address Street", { exact: false })).toBeTruthy()
     expect(getByText("Office Hours")).toBeTruthy()
   })
   it("excludes mailing address, include drop off address, excludes office hours", () => {
@@ -34,14 +34,14 @@ describe("<ApplicationAddresses>", () => {
     expect(queryByText("Send Application by US Mail")).toBe(null)
     expect(queryByText("or")).toBe(null)
     expect(getByText("Drop Off Application")).toBeTruthy()
-    expect(getByText("Drop Off Address Street")).toBeTruthy()
+    expect(getByText("Drop Off Address Street", { exact: false })).toBeTruthy()
     expect(queryByText("Office Hours")).toBe(null)
   })
   it("includes mailing address, excludes dropoff address, excludes postmarks, excludes due date", () => {
     const { getByText, queryByText } = render(<MailingNoPostmarks />)
     expect(getByText("Submit a Paper Application")).toBeTruthy()
     expect(getByText("Send Application by US Mail")).toBeTruthy()
-    expect(getByText("Mailing Address Street")).toBeTruthy()
+    expect(getByText("Mailing Address Street", { exact: false })).toBeTruthy()
     expect(getByText("Developer is not responsible for lost or delayed mail.")).toBeTruthy()
     expect(queryByText("or")).toBe(null)
     expect(queryByText("Drop Off Application")).toBe(null)
@@ -50,7 +50,7 @@ describe("<ApplicationAddresses>", () => {
     const { getByText, queryByText } = render(<MailingWithPostmarks />)
     expect(getByText("Submit a Paper Application")).toBeTruthy()
     expect(getByText("Send Application by US Mail")).toBeTruthy()
-    expect(getByText("Mailing Address Street")).toBeTruthy()
+    expect(getByText("Mailing Address Street", { exact: false })).toBeTruthy()
     expect(
       getByText(
         "Applications must be received by the deadline. If sending by U.S. Mail, the application must be postmarked by November 29th, 2021",
@@ -64,7 +64,7 @@ describe("<ApplicationAddresses>", () => {
     const { getByText, queryByText } = render(<MailingYesPostmarksNoDueDate />)
     expect(getByText("Submit a Paper Application")).toBeTruthy()
     expect(getByText("Send Application by US Mail")).toBeTruthy()
-    expect(getByText("Mailing Address Street")).toBeTruthy()
+    expect(getByText("Mailing Address Street", { exact: false })).toBeTruthy()
     expect(
       getByText(
         "Applications must be received by the deadline. If sending by U.S. Mail, the application must be received by mail no later than November 30th, 2021. Applications received after November 30th, 2021 via mail will not be accepted. Developer is not responsible for lost or delayed mail.",
@@ -78,7 +78,7 @@ describe("<ApplicationAddresses>", () => {
     const { getByText, queryByText } = render(<MailingNoPostmarksYesDueDate />)
     expect(getByText("Submit a Paper Application")).toBeTruthy()
     expect(getByText("Send Application by US Mail")).toBeTruthy()
-    expect(getByText("Mailing Address Street")).toBeTruthy()
+    expect(getByText("Mailing Address Street", { exact: false })).toBeTruthy()
     expect(
       getByText(
         "Applications must be received by the deadline. If sending by U.S. Mail, the application must be postmarked by November 29th, 2021. Developer is not responsible for lost or delayed mail.",

--- a/ui-components/src/helpers/address.tsx
+++ b/ui-components/src/helpers/address.tsx
@@ -38,9 +38,11 @@ export const MultiLineAddress = (props: AddressProps) => {
           <br />
         </>
       )}
-      <Markdown children={props.address.street || ""} />
-      <br />
-      {props.address.city}, {props.address.state} {props.address.zipCode}
+      {props.address.street} {props.address.street2}
+      {(props.address.street || props.address.street2) && <br />}
+      {props.address.city}
+      {props.address.city && (props.address.state || props.address.zipCode) && ","}{" "}
+      {props.address.state} {props.address.zipCode}
     </>
   )
 }


### PR DESCRIPTION
## Issue

- Closes #1190

## Description

QA from the initial issue: Leasing agent / pick up / drop off addresses should display the `street2` field.

## How Can This Be Tested/Reviewed?

Create a listing with a leasing agent address, ensure `street2` appears in the sidebar for the address.

<img width="342" alt="Screen Shot 2022-04-28 at 6 03 25 PM" src="https://user-images.githubusercontent.com/65367387/165866432-b4afe366-232c-46c8-a441-0696384b910a.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
