### PR TITLE
feat: set default what to expect text for coming soon listings

### DIFF
--- a/backend/core/src/migration/1651191466791-add-what-to-expect-additional-text-for-coming-soon.ts
+++ b/backend/core/src/migration/1651191466791-add-what-to-expect-additional-text-for-coming-soon.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { ListingMarketingTypeEnum } from "../listings/types/listing-marketing-type-enum"
+
+export class addWhatToExpectAdditionalTextForComingSoon1651191466791 implements MigrationInterface {
+  name = "addWhatToExpectAdditionalTextForComingSoon1651191466791"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const defaultWhatToExpect = `This property is still under construction by the property owners. If you sign up for notifications through Detroit Home Connect, we will send you updates when this property has opened up applications for residents. You can also check back later to this page for updates.`
+    await queryRunner.query(
+      `UPDATE listings SET what_to_expect = ($1) WHERE marketing_type = ($2)`,
+      [defaultWhatToExpect, ListingMarketingTypeEnum.ComingSoon]
+    )
+    await queryRunner.query(
+      `UPDATE listings SET what_to_expect_additional_text = ($1) WHERE marketing_type = ($2)`,
+      [null, ListingMarketingTypeEnum.ComingSoon]
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Issue

See Slack thread: https://exygy.slack.com/archives/C0203460K6Y/p1651186335484579?thread_ts=1651186139.167809&cid=C0203460K6Y

## Description

Listings where the marketing type is coming soon should have their own default what to expect text set.

## How Can This Be Tested/Reviewed?

Reseed on dev, change to this branch, and run the migration. The one coming soon listing should have a `what_to_expect` text of the default, and an empty `what_to_expect_additional_text`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
