### PR TITLE
Removes listing queue imports

### DIFF
--- a/backend/core/src/listings/listings.module.ts
+++ b/backend/core/src/listings/listings.module.ts
@@ -35,7 +35,6 @@ import { Program } from "../program/entities/program.entity"
     ]),
     AuthModule,
     TranslationsModule,
-    BullModule.registerQueue({ name: "listings-notifications" }),
     SmsModule,
     ActivityLogModule,
   ],

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -3,8 +3,6 @@ import { InjectRepository } from "@nestjs/typeorm"
 import { Pagination } from "nestjs-typeorm-paginate"
 import { In, Repository, SelectQueryBuilder } from "typeorm"
 import { plainToClass } from "class-transformer"
-import { Queue } from "bull"
-import { InjectQueue } from "@nestjs/bull"
 import { Listing } from "./entities/listing.entity"
 import { PropertyCreateDto, PropertyUpdateDto } from "../property/dto/property.dto"
 import { addFilters } from "../shared/query-filter"
@@ -34,7 +32,6 @@ export class ListingsService {
     @InjectRepository(UnitGroup) private readonly unitGroupRepository: Repository<UnitGroup>,
     @InjectRepository(UnitType) private readonly unitTypeRepository: Repository<UnitType>,
     @InjectRepository(Program) private readonly programRepository: Repository<Program>,
-    @InjectQueue("listings-notifications")
     private readonly translationService: TranslationsService
   ) {}
 


### PR DESCRIPTION
When testing the google translation issues, I was getting `this.translationService.translateListing is not a function`, which is also showing up in dev's paper trail logs, and I found that removing the queue imports and injection resolved that issue. We should remove those anyway, since we're not currently using them.