### PR TITLE
fix: remove link to eligibility calculator

### DIFF
--- a/sites/public/layouts/application.tsx
+++ b/sites/public/layouts/application.tsx
@@ -155,9 +155,6 @@ const Layout = (props) => {
             <a>{t("pageTitle.disclaimer")}</a>
           </Link>
         </FooterNav>
-        <FooterSection className="bg-black" small>
-          <ExygyFooter />
-        </FooterSection>
       </SiteFooter>
     </div>
   )

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -54,12 +54,7 @@ const ListingsPage = ({ initialListings }) => {
       </Head>
 
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
-      <PageHeader
-        className="listings-title"
-        title={t("pageTitle.rent")}
-        inverse={true}
-        tabNav={<FindRentalsForMeLink title={t("welcome.findRentalsForMe")} />}
-      />
+      <PageHeader className="listings-title" title={t("pageTitle.rent")} inverse={true} />
       <Drawer
         open={filterModalVisible}
         title={t("listingFilters.modalTitle")}

--- a/sites/public/pages/listings/filtered.tsx
+++ b/sites/public/pages/listings/filtered.tsx
@@ -103,12 +103,7 @@ const FilteredListingsPage = () => {
       </Head>
 
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
-      <PageHeader
-        className="listings-title"
-        title={t("pageTitle.rent")}
-        inverse={true}
-        tabNav={<FindRentalsForMeLink title={t("welcome.findRentalsForMe")} />}
-      />
+      <PageHeader className="listings-title" title={t("pageTitle.rent")} inverse={true} />
       <Drawer
         open={filterModalVisible}
         title={t("listingFilters.modalTitle")}


### PR DESCRIPTION
## Issue

- Closes #1215 

## Description

Remove the `Find rentals for me` button from the listing directory page.

## How Can This Be Tested/Reviewed?

Ensure the listing directory page and the filtered directory page does not have the button.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
