### PR TITLE
Detroit public filter fixes

### DIFF
--- a/backend/core/src/listings/dto/listing-filter-params.ts
+++ b/backend/core/src/listings/dto/listing-filter-params.ts
@@ -48,7 +48,7 @@ export class ListingFilterParams extends BaseFilter {
   })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })
-  [ListingFilterKeys.bedrooms]?: string;
+  [ListingFilterKeys.bedRoomSize]?: string;
 
   @Expose()
   @ApiProperty({

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -53,6 +53,7 @@ export class ListingsService {
       .leftJoin("listing_programs.program", "programs")
       .leftJoin("listings.unitGroups", "unitgroups")
       .leftJoin("unitgroups.amiLevels", "amilevels")
+      .leftJoin("unitgroups.unitType", "unitTypes")
       .groupBy("listings.id")
 
     innerFilteredQuery = ListingsService.addOrderByToQb(innerFilteredQuery, params)

--- a/backend/core/src/listings/tests/listings.service.spec.ts
+++ b/backend/core/src/listings/tests/listings.service.spec.ts
@@ -374,7 +374,7 @@ describe("ListingsService", () => {
 
       expect(listings.items).toEqual(mockListings)
       expect(mockInnerQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "(coalesce(unitGroups.open_waitlist, false) = :openWaitlist)",
+        "(coalesce(unitgroups.open_waitlist, false) = :openWaitlist)",
         {
           openWaitlist: true,
         }

--- a/backend/core/src/shared/query-filter/custom_filters.ts
+++ b/backend/core/src/shared/query-filter/custom_filters.ts
@@ -12,16 +12,12 @@ export function addAvailabilityQuery(qb: WhereExpression, filterValue: string) {
         inputArgs.vacantUnits = 1
         return
       case "openWaitlist":
-        if (!val.includes("closedWaitlist")) {
-          whereClause.push("coalesce(unitgroups.open_waitlist, false) = :openWaitlist")
-          inputArgs.openWaitlist = true
-        }
+        whereClause.push("coalesce(unitgroups.open_waitlist, false) = :openWaitlist")
+        inputArgs.openWaitlist = true
         return
       case "closedWaitlist":
-        if (!val.includes("openWaitlist")) {
-          whereClause.push("coalesce(unitgroups.open_waitlist, false) = :closedWaitlist")
-          inputArgs.openWaitlist = false
-        }
+        whereClause.push("coalesce(unitgroups.open_waitlist, false) = :closedWaitlist")
+        inputArgs.closedWaitlist = false
         return
       case "comingSoon":
         whereClause.push("listings.marketing_type = :marketing_type")

--- a/backend/core/src/shared/query-filter/custom_filters.ts
+++ b/backend/core/src/shared/query-filter/custom_filters.ts
@@ -1,6 +1,4 @@
-import { getMetadataArgsStorage, WhereExpression } from "typeorm"
-import { UnitGroup } from "../../units-summary/entities/unit-group.entity"
-import { UnitType } from "../../unit-types/entities/unit-type.entity"
+import { WhereExpression } from "typeorm"
 import { ListingMarketingTypeEnum } from "../../../types"
 
 export function addAvailabilityQuery(qb: WhereExpression, filterValue: string) {
@@ -8,20 +6,20 @@ export function addAvailabilityQuery(qb: WhereExpression, filterValue: string) {
   val.forEach((option) => {
     switch (option) {
       case "vacantUnits":
-        qb.andWhere("(unitGroups.total_available >= :vacantUnits)", {
+        qb.andWhere("(unitgroups.total_available >= :vacantUnits)", {
           vacantUnits: 1,
         })
         return
       case "openWaitlist":
         if (!val.includes("closedWaitlist")) {
-          qb.andWhere("(coalesce(unitGroups.open_waitlist, false) = :openWaitlist)", {
+          qb.andWhere("(coalesce(unitgroups.open_waitlist, false) = :openWaitlist)", {
             openWaitlist: true,
           })
         }
         return
       case "closedWaitlist":
         if (!val.includes("openWaitlist")) {
-          qb.andWhere("(coalesce(unitGroups.open_waitlist, false) = :closedWaitlist)", {
+          qb.andWhere("(coalesce(unitgroups.open_waitlist, false) = :closedWaitlist)", {
             closedWaitlist: false,
           })
         }

--- a/backend/core/src/shared/query-filter/custom_filters.ts
+++ b/backend/core/src/shared/query-filter/custom_filters.ts
@@ -3,36 +3,35 @@ import { ListingMarketingTypeEnum } from "../../../types"
 
 export function addAvailabilityQuery(qb: WhereExpression, filterValue: string) {
   const val = filterValue?.split(",")
+  const whereClause = []
+  const inputArgs: Record<string, number | boolean | ListingMarketingTypeEnum> = {}
   val.forEach((option) => {
     switch (option) {
       case "vacantUnits":
-        qb.andWhere("(unitgroups.total_available >= :vacantUnits)", {
-          vacantUnits: 1,
-        })
+        whereClause.push("unitgroups.total_available >= :vacantUnits")
+        inputArgs.vacantUnits = 1
         return
       case "openWaitlist":
         if (!val.includes("closedWaitlist")) {
-          qb.andWhere("(coalesce(unitgroups.open_waitlist, false) = :openWaitlist)", {
-            openWaitlist: true,
-          })
+          whereClause.push("coalesce(unitgroups.open_waitlist, false) = :openWaitlist")
+          inputArgs.openWaitlist = true
         }
         return
       case "closedWaitlist":
         if (!val.includes("openWaitlist")) {
-          qb.andWhere("(coalesce(unitgroups.open_waitlist, false) = :closedWaitlist)", {
-            closedWaitlist: false,
-          })
+          whereClause.push("coalesce(unitgroups.open_waitlist, false) = :closedWaitlist")
+          inputArgs.openWaitlist = false
         }
         return
       case "comingSoon":
-        qb.andWhere("listings.marketing_type = :marketing_type", {
-          marketing_type: ListingMarketingTypeEnum.comingSoon,
-        })
+        whereClause.push("listings.marketing_type = :marketing_type")
+        inputArgs.marketing_type = ListingMarketingTypeEnum.comingSoon
         return
       default:
         return
     }
   })
+  qb.andWhere(`(${whereClause.join(" OR ")})`, { ...inputArgs })
 }
 
 export function addBedroomsQuery(qb: WhereExpression, filterValue: string) {

--- a/backend/core/src/shared/query-filter/index.ts
+++ b/backend/core/src/shared/query-filter/index.ts
@@ -70,12 +70,7 @@ export function addFilters<FilterParams extends Array<any>, FilterFieldMap>(
           continue
         case ListingFilterKeys.bedrooms:
         case ListingFilterKeys.bedRoomSize:
-          addBedroomsQuery(
-            qb,
-            typeof filterValue === "string"
-              ? filterValue.split(",").map((val) => Number(val))
-              : [filterValue]
-          )
+          addBedroomsQuery(qb, filterValue)
           continue
         case ListingFilterKeys.minAmiPercentage:
           addMinAmiPercentageFilter(qb, parseInt(filterValue), includeNulls)

--- a/sites/public/pages/listings/filtered.tsx
+++ b/sites/public/pages/listings/filtered.tsx
@@ -21,7 +21,6 @@ import { useListingsData } from "../../lib/hooks"
 import { EnumListingFilterParamsStatus, OrderByFieldsEnum } from "@bloom-housing/backend-core/types"
 import FilterForm from "../../src/forms/filters/FilterForm"
 import { getListings } from "../../lib/helpers"
-import { FindRentalsForMeLink } from "../../lib/FindRentalsForMeLink"
 
 const FilteredListingsPage = () => {
   const router = useRouter()
@@ -92,7 +91,7 @@ const FilteredListingsPage = () => {
     rentalsFoundTitle = t("listingFilters.loading")
   } else {
     rentalsFoundTitle = t("listingFilters.rentalsFound", {
-      smart_count: listingsData?.meta.totalItems,
+      smart_count: listingsData?.meta.totalItems ?? 0,
     })
   }
 

--- a/ui-components/src/helpers/filters.ts
+++ b/ui-components/src/helpers/filters.ts
@@ -153,18 +153,6 @@ export interface ListingFilterState {
   [FrontendListingFilterStateKeys.zipcode]?: string
 }
 
-// Since it'd be tricky to OR a separate ">=" comparison with an "IN"
-// comparison, we fake it by mapping 4+ bedrooms to being IN 4,5,...,10. If we
-// ever have units with > 10 bedrooms, we'll need to update this.
-const BedroomValues = {
-  [BedroomFields.studio]: 0,
-  [BedroomFields.SRO]: 0,
-  [BedroomFields.oneBdrm]: 1,
-  [BedroomFields.twoBdrm]: 2,
-  [BedroomFields.threeBdrm]: 3,
-  [BedroomFields.fourBdrm]: "4,5,6,7,8,9,10",
-}
-
 export function encodeToBackendFilterArray(filterState: ListingFilterState) {
   const filterArray: {
     [x: string]: any
@@ -187,22 +175,6 @@ export function encodeToBackendFilterArray(filterState: ListingFilterState) {
       })
     }
   }
-
-  // Special-case the bedroom filters, since they get combined from separate fields.
-  const bedrooms = []
-  const bedroomSize = filterState?.bedRoomSize?.split(",")
-  for (const bedroomFilterType in BedroomFields) {
-    if (bedroomSize && bedroomSize.includes(bedroomFilterType)) {
-      bedrooms.push(BedroomValues[bedroomFilterType])
-    }
-  }
-  if (bedrooms.length > 0) {
-    filterArray.push({
-      $comparison: getComparisonForFilter(ListingFilterKeys.bedrooms),
-      [ListingFilterKeys.bedrooms]: bedrooms.join(),
-    })
-  }
-
   return filterArray
 }
 


### PR DESCRIPTION
## Issue
- Closes https://github.com/CityOfDetroit/bloom/issues/1218
- Closes https://github.com/CityOfDetroit/bloom/issues/1219
- Closes https://github.com/CityOfDetroit/bloom/issues/1201

## Description
This fixes 3 issues:
1. The accessibility features filter should now internally be an or filter (e.g. they need elevator or parking on site)
2. The bedroom size filters should now function correctly (e.g. sro should only show listings where a unit group has an sro unit type select)
3. when connected to dev and selected `vacant units` for example the filter should now work correctly

**dev explanation**
for the third point above: 
the issue was that the filter was acting on the "outer" `unitGroups` instead of the inner query's `unitgroups` this was causing the issue and fixing the casing fixed the issue

## How Can This Be Tested/Reviewed?
Head to https://detroit-public-dev.netlify.app/

**testing the accessibility features filter** 
select 2 or more accessibility features as filters, the listings should filter properly acting as the accessibility features are OR'd together

**testing the bedroom size filter* 
select SRO filters, the listings should filter properly acting by filtering by the listing need at least one unit group where the SRO unit type was selected (this should also hold true across other bedroom size filters)

**testing the availability filters** 
Select `Vacant Units` as the filter, the listings that appear should all have vacant units and the number of listings appearing should match the number of total listings displayed (`Page 1 of 1(3 Total Listings)` should have 1 page and 3 listings for example)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
