### PR TITLE
1194/tooltip bug

### DIFF
--- a/ui-components/src/blocks/Tooltip.tsx
+++ b/ui-components/src/blocks/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react"
+import React, { useState, useRef, useEffect } from "react"
 import useKeyPress from "../helpers/useKeyPress"
 import "./Tooltip.scss"
 
@@ -16,6 +16,10 @@ export interface TooltipPosition {
 const Tooltip = ({ className, id, text, children }: React.PropsWithChildren<TooltipProps>) => {
   const [position, setPosition] = useState<TooltipPosition | null>(null)
   const childrenWrapperRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => setPosition(null))
+  }, [])
 
   const show = () => {
     const { x, y, width, height } = childrenWrapperRef.current?.getBoundingClientRect() || {}

--- a/ui-components/src/blocks/Tooltip.tsx
+++ b/ui-components/src/blocks/Tooltip.tsx
@@ -17,10 +17,6 @@ const Tooltip = ({ className, id, text, children }: React.PropsWithChildren<Tool
   const [position, setPosition] = useState<TooltipPosition | null>(null)
   const childrenWrapperRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    window.addEventListener("scroll", () => setPosition(null))
-  }, [])
-
   const show = () => {
     const { x, y, width, height } = childrenWrapperRef.current?.getBoundingClientRect() || {}
 
@@ -32,6 +28,14 @@ const Tooltip = ({ className, id, text, children }: React.PropsWithChildren<Tool
   const hide = () => setPosition(null)
 
   useKeyPress("Escape", () => hide())
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => hide())
+
+    return () => {
+      window.removeEventListener("scroll", () => hide())
+    }
+  }, [])
 
   return (
     <div


### PR DESCRIPTION
## Issue #1194 

- Closes #1194 
- [X] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fixes a bug on tooltips in which, if you have a tooltip open either by hovering or focusing, the tooltip would still display on the screen (see video in issue) if you scrolled up or down. 

## How Can This Be Tested/Reviewed?

Entry Point: http://localhost:3000/listings

1. Click into any listing
2. Activate a tooltip by hovering or focusing
3. Scroll up or down
4. The tooltip should disappear without delay

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
