### PR TITLE
1243/filter form accessibility

### DIFF
--- a/sites/public/src/forms/filters/FilterForm.tsx
+++ b/sites/public/src/forms/filters/FilterForm.tsx
@@ -228,6 +228,7 @@ const FilterForm = (props: FilterFormProps) => {
               error={errors?.minRent !== undefined}
               errorMessage={t("errors.minGreaterThanMaxRentError")}
               validation={{ max: maxRent || minRent }}
+              readerOnly
               inputProps={{
                 onBlur: () => {
                   void trigger("minRent")
@@ -247,6 +248,7 @@ const FilterForm = (props: FilterFormProps) => {
               error={errors?.maxRent !== undefined}
               errorMessage={t("errors.maxLessThanMinRentError")}
               validation={{ min: minRent }}
+              readerOnly
               inputProps={{
                 onBlur: () => {
                   void trigger("minRent")

--- a/sites/public/src/forms/filters/FilterForm.tsx
+++ b/sites/public/src/forms/filters/FilterForm.tsx
@@ -136,7 +136,7 @@ const FilterForm = (props: FilterFormProps) => {
               type="hidden"
               register={register}
               defaultValue={EnumListingFilterParamsStatus.active}
-              labelClassName={"hidden"}
+              hidden={true}
             />
             <ViewItem
               className={"font-bold"}

--- a/sites/public/src/forms/filters/FilterForm.tsx
+++ b/sites/public/src/forms/filters/FilterForm.tsx
@@ -223,6 +223,7 @@ const FilterForm = (props: FilterFormProps) => {
               name={FrontendListingFilterStateKeys.minRent}
               type="number"
               placeholder={t("publicFilter.rentRangeMin")}
+              label={t("publicFilter.rentRangeMin")}
               register={register}
               prepend={"$"}
               defaultValue={localFilterState?.minRent}
@@ -244,6 +245,7 @@ const FilterForm = (props: FilterFormProps) => {
               type="number"
               name={FrontendListingFilterStateKeys.maxRent}
               placeholder={t("publicFilter.rentRangeMax")}
+              label={t("publicFilter.rentRangeMax")}
               register={register}
               prepend={"$"}
               defaultValue={localFilterState?.maxRent}

--- a/sites/public/src/forms/filters/FilterForm.tsx
+++ b/sites/public/src/forms/filters/FilterForm.tsx
@@ -136,6 +136,7 @@ const FilterForm = (props: FilterFormProps) => {
               type="hidden"
               register={register}
               defaultValue={EnumListingFilterParamsStatus.active}
+              labelClassName={"hidden"}
             />
             <ViewItem
               className={"font-bold"}

--- a/ui-components/__tests__/blocks/ImageCard.test.tsx
+++ b/ui-components/__tests__/blocks/ImageCard.test.tsx
@@ -16,9 +16,7 @@ describe("<ImageCard>", () => {
   })
   it("renders with a link", () => {
     const { getByAltText } = render(<ImageCard imageUrl={"/images/listing.jpg"} href="/listings" />)
-    expect(getByAltText("A picture of the building").closest("a")?.getAttribute("href")).toBe(
-      "/listings"
-    )
+    expect(getByAltText("").closest("a")?.getAttribute("href")).toBe("/listings")
   })
   it("renders with an application status bar", () => {
     const { getByText } = render(

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -100,7 +100,7 @@ const ImageCard = (props: ImageCardProps) => {
       </div>
       <figure className="image-card">
         {props.imageUrl ? (
-          <img src={props.imageUrl} alt={props.description || t("listings.buildingImageAltText")} />
+          <img src={props.imageUrl} alt={props.description || ""} />
         ) : (
           <div className={"image-card__placeholder"} />
         )}

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -32,7 +32,6 @@ export interface FieldProps {
   dataTestId?: string
   hidden?: boolean
   labelClassName?: string
-  ariaHidden?: boolean
 }
 
 const Field = (props: FieldProps) => {

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -32,6 +32,7 @@ export interface FieldProps {
   dataTestId?: string
   hidden?: boolean
   labelClassName?: string
+  ariaHidden?: boolean
 }
 
 const Field = (props: FieldProps) => {

--- a/ui-components/src/forms/FieldGroup.stories.tsx
+++ b/ui-components/src/forms/FieldGroup.stories.tsx
@@ -55,3 +55,24 @@ export const FieldGroupDescriptions = () => {
     />
   )
 }
+
+export const FieldGroupError = () => {
+  const { register } = useForm({ mode: "onChange" })
+  return (
+    <FieldGroup
+      error={true}
+      register={register}
+      name={"testInput"}
+      type={"checkbox"}
+      fields={[
+        { id: "1234", label: "Input 1" },
+        { id: "5678", label: "Input 2" },
+      ]}
+      fieldGroupClassName={"field-group-classname"}
+      fieldClassName={"field-classname"}
+      fieldLabelClassName={"text-primary"}
+      groupNote={"Group Note"}
+      groupLabel={"Group Label"}
+    />
+  )
+}

--- a/ui-components/src/forms/FieldGroup.tsx
+++ b/ui-components/src/forms/FieldGroup.tsx
@@ -70,7 +70,7 @@ const FieldGroup = ({
     return (
       <div key={item.value}>
         <input
-          aria-describedby={`${name}-error`}
+          aria-describedby={error ? `${name}-error` : name}
           aria-invalid={!!error || false}
           type={type}
           id={item.id}

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -964,7 +964,7 @@
   "listings.sections.openHouse": "Open House",
   "listings.sections.publicProgramNote": "Affordable housing properties often receive funding to house specific populations, like seniors, residents with disabilities, etc. Properties can serve more than one population. Contact this property if you are unsure if you qualify.",
   "listings.sections.verification": "Verification",
-  "listings.sections.verificationSubtitle": "Provide verification of listing data accuracty.",
+  "listings.sections.verificationSubtitle": "Provide verification of listing data accuracy.",
   "listings.sections.isVerified": "I verify that this listing data is valid.",
   "listings.seeMaximumIncomeInformation": "See Maximum Income Information",
   "listings.seePreferenceInformation": "See Preference Information",


### PR DESCRIPTION
## Issue #1243 

- Closes #1243 

## Description

This PR makes 3 accessibility improvements: 1) Image card image alt text is set to "" if specific alt text is not included, 2) Filter form FieldGroup aria-labelledby is only set to {name}-error when there is an error, otherwise it's just set to {name} and 3) Min and Max Rent fields now have labels and readeronly attached to them and the hidden field now does not render a label.

I am awaiting clarification on this line of the ticket: Closed button and Rent range fields should use screen reader only labels rather than have an empty label

## How Can This Be Tested/Reviewed?

Entry Point: http://localhost:3000/listings | https://detroit-public-dev.netlify.app/listings

Issue 1: Inspect one of the listing images (Chrome dev tools) and notice that the html tag no longer has placeholder alt text (i.e. "A picture of the building") - instead it will be blank or more specific to the listing

Issue 2: Inspect any of the checkboxes in filter form. They will have an aria-labelledby that is just the name of the element. However, if any throw an error (they shouldn't in filter form), they will have an arialabelledby that is the name + '-error', which can be tested in Storybook as FieldGroupError.

Issue 3: Inspect Min and Max Rent fields and see that the label has a class of sr-only. The hidden field (which enforces that the filter only filter active listings) now has hidden (not rendered) label to avoid accessibility errors (first Field in the filter form GridSection). 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
