### PR TITLE
fix: netlify oom build issues

### DIFF
--- a/sites/partners/netlify.toml
+++ b/sites/partners/netlify.toml
@@ -8,6 +8,7 @@ ignore = "/bin/false"
 NODE_VERSION = "14.17.6"
 YARN_VERSION = "1.22.4"
 NEXT_TELEMETRY_DISABLED = "1"
+NODE_OPTIONS = "--max_old_space_size=4096"
 
 # reminder: URLs and fragments should *not* have a trailing /
 LISTINGS_QUERY = "/listings"

--- a/sites/public/netlify.toml
+++ b/sites/public/netlify.toml
@@ -8,6 +8,7 @@ ignore = "/bin/false"
 NODE_VERSION = "14.17.6"
 YARN_VERSION = "1.22.4"
 NEXT_TELEMETRY_DISABLED = "1"
+NODE_OPTIONS = "--max_old_space_size=4096"
 
 # reminder: URLs and fragments should *not* have a trailing /
 LISTINGS_QUERY = "/listings"


### PR DESCRIPTION
No related issue, ad-hoc

For a few weeks Netlify has had an increasing frequency of oom errors during site builds. Rerunning the deploy sometimes works. After googling, this change seems to work for a lot of people experiencing the same issue.