### PR TITLE
feat: adds partners redirect

### DIFF
--- a/sites/partners/netlify.toml
+++ b/sites/partners/netlify.toml
@@ -12,3 +12,9 @@ NODE_OPTIONS = "--max_old_space_size=4096"
 
 # reminder: URLs and fragments should *not* have a trailing /
 LISTINGS_QUERY = "/listings"
+
+[[redirects]]
+from = https://detroit-partners-prod.netlify.app/*
+to = https://partners.homeconnect.detroitmi.gov/:splat
+status = 301
+force = true


### PR DESCRIPTION
This adds a redirect for partners prod so that users who go to https://detroit-partners-prod.netlify.app, will be redirected to https://partners.homeconnect.detroitmi.gov.

The documentation for this can be found at https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file. Documentation on the use of `:splat` can be found at https://docs.netlify.com/routing/redirects/redirect-options/#splats