### PR TITLE
1329/translation update for forgot password email

### DIFF
--- a/backend/core/src/migration/1655157754482-updating-forgot-password-email.ts
+++ b/backend/core/src/migration/1655157754482-updating-forgot-password-email.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class updatingForgotPasswordEmail1655157754482 implements MigrationInterface {
+  name = "updatingForgotPasswordEmail1655157754482"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [{ id }] = await queryRunner.query(`
+        SELECT 
+            t.id 
+        FROM jurisdictions j 
+            JOIN translations t ON t.jurisdiction_id = j.id
+        WHERE name = 'Detroit'`)
+    await queryRunner.query(`
+        UPDATE translations
+        SET translations = jsonb_set(translations, '{forgotPassword, resetRequest}', '"A request to reset your Detroit Home Connect website password for %{appUrl} has recently been made."')
+        WHERE id = '${id}'
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
- Closes [#issue](https://github.com/CityOfDetroit/bloom/issues/1329)

## Description
The verbiage of the forgot password referenced `bloom housing portal` when it should reference `detroit home connect`

## How Can This Be Tested/Reviewed?
create a user (or use an existing user)
go through the forgot password flow
notice that the new verbiage is in place for the forgot password email

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
