### PR TITLE
fix: additional fees header showing bug (clean)

### DIFF
--- a/ui-components/src/page_components/listing/AdditionalFees.tsx
+++ b/ui-components/src/page_components/listing/AdditionalFees.tsx
@@ -11,7 +11,12 @@ export interface AdditionalFeesProps {
 }
 
 const AdditionalFees = (props: AdditionalFeesProps) => {
-  if (!props.depositMin && !props.depositMax && !props.applicationFee && !props.footerContent) {
+  if (
+    !props.depositMin &&
+    !props.depositMax &&
+    !props.applicationFee &&
+    props.footerContent?.length === 0
+  ) {
     return <></>
   }
 


### PR DESCRIPTION
Quick fix for bug where Additional Fees header always show since it was doing a null check on an empty array and this PR implements a length check instead.