### PR TITLE
quickfix: cross-browser image sizing

### DIFF
--- a/ui-components/src/blocks/ImageCard.scss
+++ b/ui-components/src/blocks/ImageCard.scss
@@ -25,7 +25,7 @@
 
   img {
     border-radius: var(--border-radius);
-    width: 100%;
+    aspect-ratio: 16 / 9;
     height: var(--image-height);
     object-fit: cover;
   }
@@ -58,7 +58,7 @@
     }
 
     img {
-      aspect-ratio: 16 / 9;
+      width: 100%;
       display: block;
 
       &:nth-child(1) {

--- a/ui-components/src/overlays/Overlay.tsx
+++ b/ui-components/src/overlays/Overlay.tsx
@@ -67,18 +67,6 @@ export const Overlay = (props: OverlayProps) => {
     }
   }, [elForPortal, overlayRoot])
 
-  // // disable body scrolling when the overlay is open
-  // useEffect(() => {
-  //   if (props.scrollable) return
-  //   if (!(overlayRoot && elForPortal)) return
-
-  //   props.open ? disableBodyScroll(elForPortal) : enableBodyScroll(elForPortal)
-
-  //   return () => {
-  //     enableBodyScroll(elForPortal)
-  //   }
-  // }, [elForPortal, overlayRoot, props.open])
-
   return (
     elForPortal &&
     createPortal(


### PR DESCRIPTION
This PR addresses the image width discrepancy seen on the dev site between Chrome and Safari. After some discussions with @ludtkemorgan, it seems that it is coming from the browsers' handling of css specificity since the image card properties are running into the listings-row css properties and handling them differently. Switching these two properties addressed the issue, and when we bring the updated image back to Core, we should further investigate the source of this issue.
Chrome:
<img width="598" alt="Screen Shot 2022-09-14 at 12 00 55 PM" src="https://user-images.githubusercontent.com/53269332/190240458-c6c09410-bcb3-47ac-9f70-133e2eb08d88.png">
Safari:
<img width="656" alt="Screen Shot 2022-09-14 at 12 01 01 PM" src="https://user-images.githubusercontent.com/53269332/190240518-3cd2a522-30e1-431d-a180-a68841b9704f.png">