### PR TITLE
fix: allow the deletion of users

### DIFF
--- a/backend/core/src/activity-log/entities/activity-log.entity.ts
+++ b/backend/core/src/activity-log/entities/activity-log.entity.ts
@@ -17,7 +17,7 @@ export class ActivityLog extends AbstractEntity {
   @Expose()
   action: string
 
-  @ManyToOne(() => User, { nullable: true })
+  @ManyToOne(() => User, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn()
   @Expose()
   @Type(() => User)

--- a/backend/core/src/auth/entities/user-preferences.entity.ts
+++ b/backend/core/src/auth/entities/user-preferences.entity.ts
@@ -8,6 +8,7 @@ import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enu
 export class UserPreferences {
   @OneToOne(() => User, (user) => user.preferences, {
     primary: true,
+    onDelete: "CASCADE",
   })
   @JoinColumn()
   user: User

--- a/backend/core/src/migration/1665776578492-remove-activity-log-user-relationship-on-delete.ts
+++ b/backend/core/src/migration/1665776578492-remove-activity-log-user-relationship-on-delete.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class removeActivityLogUserRelationshipOnDelete1665776578492 implements MigrationInterface {
+  name = "removeActivityLogUserRelationshipOnDelete1665776578492"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" DROP CONSTRAINT "FK_458057fa75b66e68a275647da2e"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "activity_logs" DROP CONSTRAINT "FK_d54f841fa5478e4734590d44036"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD CONSTRAINT "FK_458057fa75b66e68a275647da2e" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "activity_logs" ADD CONSTRAINT "FK_d54f841fa5478e4734590d44036" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE SET NULL ON UPDATE NO ACTION`
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "activity_logs" DROP CONSTRAINT "FK_d54f841fa5478e4734590d44036"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" DROP CONSTRAINT "FK_458057fa75b66e68a275647da2e"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "activity_logs" ADD CONSTRAINT "FK_d54f841fa5478e4734590d44036" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "user_preferences" ADD CONSTRAINT "FK_458057fa75b66e68a275647da2e" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    )
+  }
+}

--- a/sites/partners/pages/index.tsx
+++ b/sites/partners/pages/index.tsx
@@ -75,9 +75,9 @@ export default function ListingsList() {
         unSortIcon: true,
         sort: "asc",
         filter: false,
-        width: 350,
-        minWidth: 100,
         cellRenderer: "formatLinkCell",
+        minWidth: 200,
+        flex: 1,
       },
       {
         headerName: t("listings.buildingAddress"),

--- a/sites/partners/pages/users/index.tsx
+++ b/sites/partners/pages/users/index.tsx
@@ -49,6 +49,8 @@ const Users = () => {
         field: "",
         sortable: true,
         unSortIcon: true,
+        flex: 1,
+        minWidth: 150,
         valueGetter: ({ data }) => {
           const { firstName, lastName } = data
           return `${firstName} ${lastName}`
@@ -70,6 +72,8 @@ const Users = () => {
         field: "email",
         sortable: true,
         unSortIcon: true,
+        flex: 1,
+        minWidth: 250,
       },
       {
         headerName: t("t.listing"),

--- a/ui-components/src/tables/AgTable.tsx
+++ b/ui-components/src/tables/AgTable.tsx
@@ -94,7 +94,6 @@ const AgTable = ({
   const columnStateLsKey = `column-state_${id}`
   const defaultColDef = {
     resizable: true,
-    maxWidth: 300,
   }
 
   const [gridColumnApi, setGridColumnApi] = useState<ColumnApi | null>(null)


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3137

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

There is a bug in how user deletion is currently setup. Due to table relationships between the user_accounts and activity_logs along with user_preferences, users are unable to be deleted if they have any preferences or have done any activities. This fixes it by adding null to the user column in activity_logs when a user is deleted and cascading deletion of user_preferences.

**NOTE:** This is slightly different from the core/HBA fix as they do not have the user_preferences table so that functionality is new.

## How Can This Be Tested/Reviewed?

In order to test this you'll need to have two accounts. One account you'll need to do an action with (e.g. close a listing) and the other account will be the one to delete the first account.

To test the the user_preference change you'll need to delete a user that has "favorited" a listing

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
