### PR TITLE
feat: add verified at field to listings

### DIFF
--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -655,6 +655,13 @@ class Listing extends BaseEntity {
   @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
   isVerified?: boolean
 
+  @Column({ type: "timestamptz", nullable: true })
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsDate({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => Date)
+  verifiedAt?: Date | null
+
   @Column({ type: "integer", nullable: true })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -193,6 +193,10 @@ export class ListingsService {
       }
     })
     listingDto.unitsAvailable = availableUnits
+    let newVerifyDate = listingDto.isVerified === false ? null : listing.verifiedAt
+    if (listingDto.isVerified === true && !listing.verifiedAt) {
+      newVerifyDate = new Date()
+    }
     Object.assign(listing, {
       ...plainToClass(Listing, listingDto, { excludeExtraneousValues: false }),
       publishedAt:
@@ -203,6 +207,7 @@ export class ListingsService {
         listing.status !== ListingStatus.closed && listingDto.status === ListingStatus.closed
           ? new Date()
           : listing.closedAt,
+      verifiedAt: newVerifyDate,
       property: plainToClass(
         PropertyUpdateDto,
         {

--- a/backend/core/src/migration/1668201101384-change-is-verified-type.ts
+++ b/backend/core/src/migration/1668201101384-change-is-verified-type.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class changeIsVerifiedType1668201101384 implements MigrationInterface {
+  name = "changeIsVerifiedType1668201101384"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "listings" ADD "verified_at" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(
+      `UPDATE "listings" SET "verified_at" = "updated_at" where is_verified = 'true'`
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "listings" DROP COLUMN "verified_at"`)
+  }
+}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1429

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This adds a new field to the listings table called `verified_at`. This will allow us the ability to see when a specific listing was verified. For now I am not deleting the `is_verified` column to both simplify this change and also to make it so we don't need to do a front-end and backend change at the same time. Once this change is completed we can remove the `is_verified` field and update all references to use the new `verified_at` if we decide it is no longer needed.

## How Can This Be Tested/Reviewed?

This change has a migration that will add the new verified_at and also populate any existing listing that is already verified. To test this make sure that the migration properly runs and also when you verify a property in partners the verified_at is populated. When a listing is un-verified the `verified_at` field should turn to null.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
