### PR TITLE
fix: correct get-assistance headings

### DIFF
--- a/sites/public/page_content/resources/sidebar.md
+++ b/sites/public/page_content/resources/sidebar.md
@@ -1,6 +1,6 @@
 <RenderIf language="default">
 
-#### Contact
+### Contact
 
 **City of Detroit Housing and Revitalization Department**
 
@@ -12,7 +12,7 @@ For general program inquiries, you may call the Housing and Revitalization Depar
 
 <RenderIf language="es">
 
-#### Contacto
+### Contacto
 
 **Departamento de Vivienda y Revitalización de la ciudad de Detroit**
 
@@ -24,7 +24,7 @@ Para consultas generales sobre el programa, comuníquese con el Departamento de 
 
 <RenderIf language="ar">
 
-#### الاتصال
+### الاتصال
 
 **إدارة الإسكان والتعمير بمدينة ديترويت**
 
@@ -36,7 +36,7 @@ Para consultas generales sobre el programa, comuníquese con el Departamento de 
 
 <RenderIf language="bn">
 
-#### যোগাযোগ
+### যোগাযোগ
 
 **ডেট্রয়েট সিটির হাউজিং এবং রিভাইটালাইজেশন ডিপার্টমেন্ট**
 

--- a/sites/public/pages/additional-resources.tsx
+++ b/sites/public/pages/additional-resources.tsx
@@ -93,11 +93,11 @@ const AdditionalResources = () => {
               <Markdown
                 options={{
                   overrides: {
-                    h4: {
+                    h3: {
                       component: ({ children, ...props }) => (
-                        <h4 {...props} className="text-caps-underline">
+                        <h3 {...props} className="text-tiny text-caps-underline">
                           {children}
-                        </h4>
+                        </h3>
                       ),
                     },
                     RenderIf,

--- a/sites/public/pages/get-assistance.tsx
+++ b/sites/public/pages/get-assistance.tsx
@@ -40,11 +40,11 @@ export default function GetAssistance() {
               <Markdown
                 options={{
                   overrides: {
-                    h4: {
+                    h3: {
                       component: ({ children, ...props }) => (
-                        <h4 {...props} className="text-caps-underline">
+                        <h3 {...props} className="text-tiny text-caps-underline">
                           {children}
-                        </h4>
+                        </h3>
                       ),
                     },
                     RenderIf,

--- a/sites/public/pages/housing-basics.tsx
+++ b/sites/public/pages/housing-basics.tsx
@@ -96,11 +96,11 @@ export default function HousingBasics() {
               <Markdown
                 options={{
                   overrides: {
-                    h4: {
+                    h3: {
                       component: ({ children, ...props }) => (
-                        <h4 {...props} className="text-caps-underline">
+                        <h3 {...props} className="text-tiny text-caps-underline">
                           {children}
-                        </h4>
+                        </h3>
                       ),
                     },
                     RenderIf,

--- a/sites/public/src/ResourceLinkCard.tsx
+++ b/sites/public/src/ResourceLinkCard.tsx
@@ -22,7 +22,7 @@ const ResourceLinkCard = (props: ResourceLinkCardProps) => {
           symbol={iconSymbol}
           className="ml-2 px-2 info-cards__title"
         />
-        <h3 className="font-semibold mt-0">{title}</h3>
+        <h2 className="font-semibold mt-0">{title}</h2>
         <div className="mb-4">{subtitle}</div>
         <LinkButton unstyled className="bg-opacity-0 ms-0" href={linkUrl}>
           {linkLabel}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3269

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR corrects the heading order on the get-assistance page. Since it also touches the sidebar content (Contact info), it adjusts heading levels for housing-basics and additional-resources but in ways that correct the order there as well.

## How Can This Be Tested/Reviewed?

This can be tested by using inspect element on the page and ensuring that the content of the footer doesn't contain heading tags. 
OR
Repeat the steps below on the get-assistance page along with housing basics and additional resources.
1. Click your voiceover modifier key (in my screenshot it is caps lock) + U
2. Use the left or right arrow key until you locate the Headings Menu
3. Use the down arrow to the headings on the page and their respective levels
4. Ensure it matches the discussed changes above

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
