### PR TITLE
fix: tabIndex approach

### DIFF
--- a/sites/public/pages/finder.tsx
+++ b/sites/public/pages/finder.tsx
@@ -4,12 +4,16 @@ import {
   listingFeatures,
   Region,
 } from "@bloom-housing/shared-helpers"
-import { ButtonGroup, Card, Form, t } from "@bloom-housing/ui-components"
-import { Button } from "../../../detroit-ui-components/src/actions/Button"
-import { HeadingGroup } from "../../../detroit-ui-components/src/headers/HeadingGroup"
-import { StepHeader } from "../../../detroit-ui-components/src/headers/StepHeader"
-import { ProgressNav } from "../../../detroit-ui-components/src/navigation/ProgressNav"
-import { AppearanceStyleType } from "../../../detroit-ui-components/src/global/AppearanceTypes"
+import {
+  AppearanceStyleType,
+  Button,
+  ButtonGroup,
+  Card,
+  Form,
+  ProgressNav,
+  StepHeader,
+  t,
+} from "@bloom-housing/ui-components"
 import axios from "axios"
 import router from "next/router"
 
@@ -254,21 +258,21 @@ const Finder = () => {
   return (
     <Layout>
       <Form onSubmit={handleSubmit(onSubmit)} className="bg-gray-300 border-t border-gray-450">
-        <div tabIndex={-1} ref={finderBody} className="md:mb-8 mt-8 mx-auto max-w-5xl">
+        <div className="md:mb-8 mt-8 mx-auto max-w-5xl">
           <ProgressHeader />
           <Card className="finder-card">
             {formData?.length > 0 && (
               <div>
                 <Card.Header>
-                  <HeadingGroup
-                    headingPriority={3}
-                    heading={
-                      !isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")
-                    }
-                    subheading={
-                      !isDisclaimer ? activeQuestion.subtitle : t("finder.disclaimer.subtitle")
-                    }
-                  />
+                  {/* Deconstructed header group to allow for ref */}
+                  <hgroup role="group">
+                    <h3 tabIndex={0} ref={finderBody}>
+                      {!isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")}
+                    </h3>
+                    <p aria-roledescription="subtitle">
+                      {!isDisclaimer ? activeQuestion.subtitle : t("finder.disclaimer.subtitle")}
+                    </p>
+                  </hgroup>
                 </Card.Header>
                 <Card.Section className={!isDisclaimer ? "" : "finder-disclaimer"}>
                   {!isDisclaimer ? (

--- a/sites/public/pages/finder.tsx
+++ b/sites/public/pages/finder.tsx
@@ -46,7 +46,7 @@ const Finder = () => {
   const [questionIndex, setQuestionIndex] = useState<number>(0)
   const [formData, setFormData] = useState<FinderQuestion[]>([])
   const [isDisclaimer, setIsDisclaimer] = useState<boolean>(false)
-  const finderBody = useRef(null)
+  const finderSectionHeader = useRef(null)
   const minRent = watch("minRent")
   const maxRent = watch("maxRent")
 
@@ -241,18 +241,19 @@ const Finder = () => {
       setFormData(formCopy)
       if (questionIndex >= formData.length - 1) setIsDisclaimer(true)
       setQuestionIndex(questionIndex + 1)
-      finderBody.current.focus()
+      finderSectionHeader.current.focus()
     }
   }
   const previousQuestion = () => {
     setIsDisclaimer(false)
     setQuestionIndex(questionIndex - 1)
-    finderBody.current.focus()
+    finderSectionHeader.current.focus()
   }
 
   const skipToListings = () => {
     setIsDisclaimer(true)
     setQuestionIndex(formData.length)
+    finderSectionHeader.current.focus()
   }
 
   return (
@@ -266,7 +267,7 @@ const Finder = () => {
                 <Card.Header>
                   {/* Deconstructed header group to support ref */}
                   <hgroup role="group">
-                    <h3 tabIndex={-1} ref={finderBody}>
+                    <h3 tabIndex={-1} ref={finderSectionHeader}>
                       {!isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")}
                     </h3>
                     <p aria-roledescription="subtitle">

--- a/sites/public/pages/finder.tsx
+++ b/sites/public/pages/finder.tsx
@@ -264,7 +264,7 @@ const Finder = () => {
             {formData?.length > 0 && (
               <div>
                 <Card.Header>
-                  {/* Deconstructed header group to allow for ref */}
+                  {/* Deconstructed header group to support ref */}
                   <hgroup role="group">
                     <h3 tabIndex={-1} ref={finderBody}>
                       {!isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")}

--- a/sites/public/pages/finder.tsx
+++ b/sites/public/pages/finder.tsx
@@ -4,16 +4,13 @@ import {
   listingFeatures,
   Region,
 } from "@bloom-housing/shared-helpers"
+import { ButtonGroup, Card, Form, t } from "@bloom-housing/ui-components"
 import {
   AppearanceStyleType,
   Button,
-  ButtonGroup,
-  Card,
-  Form,
-  ProgressNav,
   StepHeader,
-  t,
-} from "@bloom-housing/ui-components"
+  ProgressNav,
+} from "../../../detroit-ui-components"
 import axios from "axios"
 import router from "next/router"
 

--- a/sites/public/pages/finder.tsx
+++ b/sites/public/pages/finder.tsx
@@ -266,7 +266,7 @@ const Finder = () => {
                 <Card.Header>
                   {/* Deconstructed header group to allow for ref */}
                   <hgroup role="group">
-                    <h3 tabIndex={0} ref={finderBody}>
+                    <h3 tabIndex={-1} ref={finderBody}>
                       {!isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")}
                     </h3>
                     <p aria-roledescription="subtitle">


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1536 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This change improves the screen reader experience when navigating between pages of the Rental Finder form. Previously, we were approaching this issue with the hard rule that no non-actionable item should ever have the tabIndex attribute. After more research and discussions with LH, it seems that approaching this rule with more nuance could improve the SR experience. Also to note, our current implementation allows for the container to receive focus but that hasn't been performing consistently nor helping the SR experience. It was made more as a temporary fix and I imagine this to be more precedent setting on our use of tabIndex.

Resources to support:
1) Representatives of LH shared that tabIndex attributes on non-actionable items is a pattern that they are familiar with and if done with intention, can be assistive to their experience.
2) https://egghead.io/lessons/react-appropriately-set-the-focus-on-each-page-load-of-a-web-application (Starting at time 4:50) Note that this developer acknowledges the exception but then uses a tabIndex of 0 which will appear in the tab navigation of the page. In my opinion, this creates unnecessary confusion since the desired behavior is for the heading to be focusable but adding it to the tab order suggests that it is actionable. This is avoidable based on the resource below. Thank you @slowbot for the resource!
3) https://webaim.org/techniques/keyboard/tabindex#zero-negative-one
This resource contextualizes the decision to use a tabIndex of -1 and the pieces that says "Examples include a modal dialog window that should be focused when it is opened" seems to support the case for non-actionable focus in specific contexts.
4) https://web.dev/using-tabindex/#managing-focus-at-the-page-level
This section seems to be the most direct guidance supporting our case.


Alternatives resources that state to never is tabIndex on non-actionable elements, however, as @emilyjablonski brought up, they both seem to do this in reference to tabIndex=0 rather than tabIndex=-1. Either way, they serve as context to avoid a11y mistakes:
https://www.a11yproject.com/posts/how-to-use-the-tabindex-attribute/
https://web.dev/using-tabindex/

Final Thoughts:
I believe that this is a clear improvement since we were already using tabIndex on a non-actionable item but wanted to highlight the different views going on around tabIndex. **If we would like stick to this principle, the best alternatives seems to be resetting focus on the skip to main content button (when implemented).**

## How Can This Be Tested/Reviewed?

This can be tested by running this locally or opening the preview with Mac VoiceOver and going between questions on the rental finder page. Additionally, the preview can be tested in BrowserStack with NVDA enabled. 

Note that the focus will not land on the header for the first question since this issue covers the UX between questions. 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
