### PR TITLE
3268/listing card headers

### DIFF
--- a/detroit-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/detroit-ui-components/src/page_components/listing/ListingCard.tsx
@@ -116,7 +116,9 @@ const ListingCard = (props: ListingCardProps) => {
               contentProps?.tableHeader?.priority ?? 3,
               "tableHeader"
             )}
-            <p className="table-subheader"> {contentProps?.tableSubheader?.text}</p>
+            <p className="table-subheader" aria-roledescription="subtitle">
+              {contentProps?.tableSubheader?.text}
+            </p>
             {cardTags && cardTags?.length > 0 && (
               <div className={"inline-flex flex-wrap justify-start w-full"}>
                 {cardTags?.map((cardTag, index) => {

--- a/detroit-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/detroit-ui-components/src/page_components/listing/ListingCard.tsx
@@ -11,6 +11,7 @@ import "./ListingCard.scss"
 
 export interface ListingCardHeader {
   customClass?: string
+  priority?: number
   text: string
 }
 
@@ -91,8 +92,13 @@ const ListingCard = (props: ListingCardProps) => {
   const getContentHeader = () => {
     return (
       <>
-        {getHeader(contentProps?.contentHeader, 2, "cardHeader", "order-1")}
-        {getHeader(contentProps?.contentSubheader, 3, "cardSubheader", "order-2")}
+        {getHeader(
+          contentProps?.contentHeader,
+          contentProps?.contentHeader?.priority ?? 2,
+          "cardHeader",
+          "order-1"
+        )}
+        <p className="card-subheader order-2">{contentProps?.contentSubheader?.text}</p>
       </>
     )
   }
@@ -105,8 +111,12 @@ const ListingCard = (props: ListingCardProps) => {
               <hr className={"mb-2"} />
             )}
           <div className={"listings-row_headers"}>
-            {getHeader(contentProps?.tableHeader, 4, "tableHeader")}
-            {getHeader(contentProps?.tableSubheader, 5, "tableSubheader")}
+            {getHeader(
+              contentProps?.tableHeader,
+              contentProps?.tableHeader?.priority ?? 3,
+              "tableHeader"
+            )}
+            <p className="table-subheader"> {contentProps?.tableSubheader?.text}</p>
             {cardTags && cardTags?.length > 0 && (
               <div className={"inline-flex flex-wrap justify-start w-full"}>
                 {cardTags?.map((cardTag, index) => {

--- a/sites/public/lib/helpers.tsx
+++ b/sites/public/lib/helpers.tsx
@@ -242,7 +242,7 @@ export const getListings = (listings) => {
         cellClassName: "px-5 py-3",
       }}
       contentProps={{
-        contentHeader: { text: listing.name },
+        contentHeader: { text: listing.name, priority: 3 },
         contentSubheader: { text: getListingCardSubtitle(listing.buildingAddress) },
         tableHeader: { text: listing.showWaitlist ? t("listings.waitlist.open") : null },
       }}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3268

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR updates the Listing Card to fix the heading order on the listings page. Since the listing card header is correctly an h2 in core, I added a prop rather hard code the heading level change into the listing card. Additionally, the address and table subheading were changed to p tags rather than headers (and the table heading was adjusting accordingly). 

This decision is based on conversations with LH with support from online articles linked below. The main gist is that headings distinguish sections and subheadings or subtitles simply add more detail to describe the same section. The common example online is a book title (h1) and author byline (p tag rather than h2). Also, note that the resources below discuss the hgroup element which is not currently used by assistive technology. It is interesting to learn about but since it is largely driven by theory, I didn't include it in this solution

https://www.a11yproject.com/posts/how-to-accessible-heading-structure/
https://www.tpgi.com/subheadings-subtitles-alternative-titles-and-taglines-in-html/

**On implementation:** there is clearly room for improvement in the Listing Card. This is most clearly seen in the use of the ListingCardHeader interface in cases where the priority or classNames aren't taken into account, however, for this ticket, I felt this would quickly drift out of scope.

## How Can This Be Tested/Reviewed?

This can be tested by going to the listings page and ensuring that the headings are correctly ordered (between "Rent Affordable Housing", "All Rentals", and <the listing name>) and that the address is now a p tag. Also, ensure there are no visual changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
