### PR TITLE
fix: release issue with filter grid

### DIFF
--- a/sites/public/styles/blocks.scss
+++ b/sites/public/styles/blocks.scss
@@ -1,42 +1,42 @@
-#__next {
-  .image-card-tag__wrapper {
-    .tag {
-      @apply text-base;
-      border-radius: 4px;
-      font-weight: bold;
-      margin-inline-end: 12px;
-      padding: 8px 16px;
+/** Blocks */
 
-      @screen md {
-        margin-inline-end: 36px;
-      }
-    }
+.image-card-tag__wrapper {
+  .tag {
+    @apply text-base;
+    border-radius: 4px;
+    font-weight: bold;
+    margin-inline-end: 12px;
+    padding: 8px 16px;
 
-    .tag__icon {
-      padding-inline-end: 10px;
-
-      svg {
-        height: 20px;
-        width: 20px;
-      }
+    @screen md {
+      margin-inline-end: 36px;
     }
   }
 
-  .action-block.has-bold-header .action-block__header {
-    font-weight: 600;
-  }
+  .tag__icon {
+    padding-inline-end: 10px;
 
-  .media-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    column-gap: 1rem;
-    row-gap: 2rem;
-    .media-grid__cell {
-      width: 100%;
-      @screen md {
-        width: calc(50% - 0.5rem);
-      }
+    svg {
+      height: 20px;
+      width: 20px;
+    }
+  }
+}
+
+.action-block.has-bold-header .action-block__header {
+  font-weight: 600;
+}
+
+.media-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  column-gap: 1rem;
+  row-gap: 2rem;
+  .media-grid__cell {
+    width: 100%;
+    @screen md {
+      width: calc(50% - 0.5rem);
     }
   }
 }

--- a/sites/public/styles/footers.scss
+++ b/sites/public/styles/footers.scss
@@ -1,101 +1,100 @@
-/** Footer */
-#__next {
-  footer.site-footer > .footer-row:first-of-type {
-    padding-top: 2rem;
+/** Footers */
+
+footer.site-footer > .footer-row:first-of-type {
+  padding-top: 2rem;
+}
+
+.footer-sections {
+  padding: 2rem 1.25rem;
+  @apply max-w-5xl;
+  margin: auto;
+}
+
+.footer-sock {
+  @apply text-gray-600;
+  padding: 1rem 0 2rem;
+}
+
+footer.site-footer .footer-sock a {
+  @apply text-gray-600;
+}
+
+.footer-copyright {
+  margin-top: 1.25rem;
+}
+
+.footer-nav {
+  font-size: 0.875rem;
+}
+
+footer.site-footer img {
+  margin-top: -16px; // Negative margin to center around shield
+  width: 50px;
+
+  @screen md {
+    margin-top: -23px;
+    width: 74px;
+  }
+}
+
+@media (min-width: $header-desktop-min-size) {
+  .footer-sections {
+    display: flex;
+    justify-content: space-between;
+    padding: 1.5rem 1.25rem;
   }
 
-  .footer-sections {
-    padding: 2rem 1.25rem;
-    @apply max-w-5xl;
-    margin: auto;
+  .footer-sections > * {
+    flex-basis: 45%;
+  }
+
+  .footer-info {
+    display: flex;
+  }
+
+  .footer-info__column {
+    max-width: 20rem;
   }
 
   .footer-sock {
-    @apply text-gray-600;
-    padding: 1rem 0 2rem;
+    padding: 1.375rem 3.125rem;
   }
 
-  footer.site-footer .footer-sock a {
-    @apply text-gray-600;
+  .footer-sock .footer-sock__inner {
+    display: flex;
+    justify-content: space-between;
+    max-width: initial;
   }
 
   .footer-copyright {
-    margin-top: 1.25rem;
+    margin-top: 0;
+    max-width: initial;
   }
 
-  .footer-nav {
-    font-size: 0.875rem;
+  .footer-sock .footer-nav {
+    margin-top: 0;
+    text-align: right;
+    width: initial;
   }
 
-  footer.site-footer img {
-    margin-top: -16px; // Negative margin to center around shield
-    width: 50px;
+  .footer-nav a {
+    display: inline;
+    margin-left: 2.25rem;
+    width: auto;
+  }
+}
 
-    @screen md {
-      margin-top: -23px;
-      width: 74px;
-    }
+@screen lg {
+  .footer-sections {
+    padding: 2.25rem 1.25rem;
   }
 
-  @media (min-width: $header-desktop-min-size) {
-    .footer-sections {
-      display: flex;
-      justify-content: space-between;
-      padding: 1.5rem 1.25rem;
-    }
-
-    .footer-sections > * {
-      flex-basis: 45%;
-    }
-
-    .footer-info {
-      display: flex;
-    }
-
-    .footer-info__column {
-      max-width: 20rem;
-    }
-
-    .footer-sock {
-      padding: 1.375rem 3.125rem;
-    }
-
-    .footer-sock .footer-sock__inner {
-      display: flex;
-      justify-content: space-between;
-      max-width: initial;
-    }
-
-    .footer-copyright {
-      margin-top: 0;
-      max-width: initial;
-    }
-
-    .footer-sock .footer-nav {
-      margin-top: 0;
-      text-align: right;
-      width: initial;
-    }
-
-    .footer-nav a {
-      display: inline;
-      margin-left: 2.25rem;
-      width: auto;
-    }
+  .footer-sock .footer-copyright {
+    @apply text-base;
+    width: auto;
   }
 
-  @screen lg {
-    .footer-sections {
-      padding: 2.25rem 1.25rem;
-    }
-
-    .footer-sock .footer-copyright {
-      @apply text-base;
-      width: auto;
-    }
-
-    .footer-sock .footer-nav {
-      @apply text-base;
-    }
+  .footer-sock .footer-nav {
+    @apply text-base;
   }
 }

--- a/sites/public/styles/forms.scss
+++ b/sites/public/styles/forms.scss
@@ -1,118 +1,118 @@
-#__next {
-  .progress-nav {
-    padding-top: 1rem;
-    padding-bottom: 1.5rem;
-    @screen md {
-      padding-bottom: 3rem;
-      padding-top: 2rem;
-    }
-  }
+/** Forms */
 
-  li.progress-nav__item,
-  h1.form-card__header_title {
-    padding: 0;
-    text-transform: capitalize;
+.progress-nav {
+  padding-top: 1rem;
+  padding-bottom: 1.5rem;
+  @screen md {
+    padding-bottom: 3rem;
+    padding-top: 2rem;
   }
+}
 
-  // For the eligibility questionnaire, there are five headers, so give each 20% of the full navbar
-  // width. (If we reuse this class for other navigation UI elements, with a different number of
-  // navbar items, we'll need to refactor this.)
-  li.progress-nav__item {
-    width: 20%;
+li.progress-nav__item,
+h1.form-card__header_title {
+  padding: 0;
+  text-transform: capitalize;
+}
+
+// For the eligibility questionnaire, there are five headers, so give each 20% of the full navbar
+// width. (If we reuse this class for other navigation UI elements, with a different number of
+// navbar items, we'll need to refactor this.)
+li.progress-nav__item {
+  width: 20%;
+}
+
+.progress-nav__item {
+  &.is-active:before {
+    @apply bg-primary-dark;
   }
-
-  .progress-nav__item {
-    &.is-active:before {
-      @apply bg-primary-dark;
-    }
-    &.is-disabled:before {
-      @apply bg-white;
-      @apply border-2;
-      @apply border-primary;
-    }
-    &:before {
-      @apply bg-primary;
-      @apply border-0;
-    }
-    &:after {
-      @apply bg-primary;
-      height: 2px;
-      margin-top: -1px; // so the connecting line is vertically centered between the pips
-    }
-    &.is-active > a {
-      @apply text-primary-dark;
-    }
-    a {
-      @apply text-primary;
-    }
+  &.is-disabled:before {
+    @apply bg-white;
+    @apply border-2;
+    @apply border-primary;
   }
-
-  // Body text should have normal font weight
-  .field-note {
-    @apply font-normal;
+  &:before {
+    @apply bg-primary;
+    @apply border-0;
   }
+  &:after {
+    @apply bg-primary;
+    height: 2px;
+    margin-top: -1px; // so the connecting line is vertically centered between the pips
+  }
+  &.is-active > a {
+    @apply text-primary-dark;
+  }
+  a {
+    @apply text-primary;
+  }
+}
 
-  .finder-card {
-    --content-margin-inline-desktop: var(--bloom-s20);
-    --content-margin-inline-mobile: var(--bloom-s4);
-    --header-padding-block: var(--bloom-s12) var(--bloom-s8);
-    .heading-group {
-      --subheading-margin: var(--bloom-s4) 0rem;
-    }
-    .button-group {
-      --padding-inline-desktop: 0rem;
-      --padding-inline-mobile: 0rem;
-      .button-group__column {
-        .button {
-          --normal-rounded: 3.75rem;
-          --normal-padding: var(--bloom-s2) var(--bloom-s4);
-          --normal-font-size: var(--bloom-font-size-base);
-        }
+// Body text should have normal font weight
+.field-note {
+  @apply font-normal;
+}
+
+.finder-card {
+  --content-margin-inline-desktop: var(--bloom-s20);
+  --content-margin-inline-mobile: var(--bloom-s4);
+  --header-padding-block: var(--bloom-s12) var(--bloom-s8);
+  .heading-group {
+    --subheading-margin: var(--bloom-s4) 0rem;
+  }
+  .button-group {
+    --padding-inline-desktop: 0rem;
+    --padding-inline-mobile: 0rem;
+    .button-group__column {
+      .button {
+        --normal-rounded: 3.75rem;
+        --normal-padding: var(--bloom-s2) var(--bloom-s4);
+        --normal-font-size: var(--bloom-font-size-base);
       }
     }
-    h1 {
+  }
+  h1 {
+    font-size: var(--bloom-s5);
+  }
+  h3 {
+    font-size: 1.625rem;
+  }
+  @media (max-width: $screen-sm) {
+    h3 {
       font-size: var(--bloom-s5);
     }
-    h3 {
-      font-size: 1.625rem;
-    }
-    @media (max-width: $screen-sm) {
-      h3 {
-        font-size: var(--bloom-s5);
-      }
-    }
   }
+}
 
-  .finder-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    .field {
-      --leftward-margin: 0rem;
-    }
+.finder-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  .field {
+    --leftward-margin: 0rem;
   }
-  .finder-grid__multiselect {
-    row-gap: 0.5rem;
-    column-gap: 0.5rem;
+}
+.finder-grid__multiselect {
+  row-gap: 0.5rem;
+  column-gap: 0.5rem;
 
-    .finder-grid__field {
-      width: 100%;
-      @screen md {
-        width: calc(50% - 0.25rem);
-      }
+  .finder-grid__field {
+    width: 100%;
+    @screen md {
+      width: calc(50% - 0.25rem);
     }
   }
-  .finder-grid__rental_costs {
-    row-gap: 1rem;
-    column-gap: 1rem;
-    .finder-grid__field {
-      width: 100%;
-      @screen md {
-        width: calc(50% - 0.5rem);
-      }
+}
+.finder-grid__rental_costs {
+  row-gap: 1rem;
+  column-gap: 1rem;
+  .finder-grid__field {
+    width: 100%;
+    @screen md {
+      width: calc(50% - 0.5rem);
     }
-    .finder-grid__row {
-      width: 100%;
-    }
+  }
+  .finder-grid__row {
+    width: 100%;
   }
 }

--- a/sites/public/styles/headers.scss
+++ b/sites/public/styles/headers.scss
@@ -1,325 +1,325 @@
-#__next {
-  .site-header {
-    .navbar-notice-hide {
-      display: none;
-    }
+/** Headers */
 
-    .navbar-container {
-      border: none;
+.site-header {
+  .navbar-notice-hide {
+    display: none;
+  }
 
-      .navbar {
-        align-items: center;
-        height: auto;
-        max-height: none;
-        padding: var(--bloom-s6) 0;
+  .navbar-container {
+    border: none;
+
+    .navbar {
+      align-items: center;
+      height: auto;
+      max-height: none;
+      padding: var(--bloom-s6) 0;
+
+      @media (min-width: $header-desktop-min-size) {
+        padding: 0 12px;
+        width: 100%;
+      }
+
+      @screen lg {
+        padding: 0 50px;
+        width: 100%;
+      }
+
+      @screen xl {
+        justify-content: center;
+      }
+
+      .navbar-menu {
+        height: 48px;
+        margin-right: 12px;
+        min-width: 48px;
+        width: 48px;
 
         @media (min-width: $header-desktop-min-size) {
-          padding: 0 12px;
-          width: 100%;
-        }
-
-        @screen lg {
-          padding: 0 50px;
+          margin: 40px 0 24px;
           width: 100%;
         }
 
         @screen xl {
+          margin: 48px 0 32px;
+        }
+
+        .button.navbar-mobile-menu-button {
+          align-items: center;
           justify-content: center;
+          margin: 0;
+          padding: 0;
         }
 
-        .navbar-menu {
-          height: 48px;
-          margin-right: 12px;
-          min-width: 48px;
-          width: 48px;
-
-          @media (min-width: $header-desktop-min-size) {
-            margin: 40px 0 24px;
-            width: 100%;
-          }
-
-          @screen xl {
-            margin: 48px 0 32px;
-          }
-
-          .button.navbar-mobile-menu-button {
-            align-items: center;
-            justify-content: center;
-            margin: 0;
-            padding: 0;
-          }
-
-          .button {
-            width: 60px;
-          }
-
-          .button__content {
-            display: none;
-          }
-
-          .button__icon {
-            margin: 0;
-          }
-
-          .ui-base svg {
-            height: 18px;
-            width: 21px;
-          }
-
-          .navbar-link {
-            @apply text-primary;
-            align-items: center;
-            display: flex;
-            font-size: 0.95rem;
-            @screen lg {
-              font-size: 1.125rem;
-            }
-            font-weight: 700;
-            height: 40px;
-            padding: 1rem;
-            text-transform: none;
-            border: none;
-          }
-
-          .navbar-link__sign-in {
-            margin-inline-start: 1rem;
-            padding-inline-start: 2rem;
-            position: relative;
-            min-width: max-content;
-          }
-
-          // This is a little hacky to get the divider line to the left of the "sign in" link, but
-          // this is the simplest way to do it without making significant changes to the SiteHeader
-          // component
-          .navbar-link__sign-in:before {
-            border-inline-start: 3px solid $tailwind-primary;
-            content: "";
-            height: 18px;
-            inset-inline-start: 0;
-            position: absolute;
-          }
-
-          .navbar-link__sign-up {
-            border: 2px solid $tailwind-primary;
-            border-radius: 44px;
-            min-width: max-content;
-          }
-
-          .navbar-link.navbar-link__sign-up:hover {
-            @apply text-white;
-            background-color: $tailwind-primary;
-            border: 2px solid $tailwind-primary;
-            border-radius: 44px;
-          }
-
-          .navbar-link:hover {
-            @apply text-primary-dark;
-            border: none;
-          }
-
-          .navbar-dropdown-container {
-            display: flex;
-            margin-left: 0px;
-            border-top: 1px transparent;
-            margin-top: 7px;
-            width: auto;
-            .navbar-dropdown {
-              .navbar-dropdown-item-container {
-                display: flex;
-              }
-              .navbar-dropdown-item {
-                flex: 1 1 auto;
-                font-size: 0.75rem;
-              }
-            }
-          }
-
-          .navbar-mobile-menu-button {
-            @apply flex;
-            border: none;
-            margin: 2.75rem 0.5rem 0;
-            padding: 0 0.5rem 0.75rem;
-          }
-
-          .ui-icon svg rect {
-            fill: $tailwind-primary;
-          }
+        .button {
+          width: 60px;
         }
 
-        .navbar-logo {
-          @media (min-width: $header-desktop-min-size) {
-            padding: 48px 0 32px 0;
+        .button__content {
+          display: none;
+        }
+
+        .button__icon {
+          margin: 0;
+        }
+
+        .ui-base svg {
+          height: 18px;
+          width: 21px;
+        }
+
+        .navbar-link {
+          @apply text-primary;
+          align-items: center;
+          display: flex;
+          font-size: 0.95rem;
+          @screen lg {
+            font-size: 1.125rem;
           }
+          font-weight: 700;
+          height: 40px;
+          padding: 1rem;
+          text-transform: none;
+          border: none;
+        }
 
-          @screen xl {
-            padding: 48px 0 32px;
-          }
+        .navbar-link__sign-in {
+          margin-inline-start: 1rem;
+          padding-inline-start: 2rem;
+          position: relative;
+          min-width: max-content;
+        }
 
-          .logo {
-            background-color: initial;
-            box-shadow: none;
-            height: 100%;
-            margin: 0;
-            max-height: 15rem;
-            max-width: 100%;
-            padding: 0;
-            width: 100%;
+        // This is a little hacky to get the divider line to the left of the "sign in" link, but
+        // this is the simplest way to do it without making significant changes to the SiteHeader
+        // component
+        .navbar-link__sign-in:before {
+          border-inline-start: 3px solid $tailwind-primary;
+          content: "";
+          height: 18px;
+          inset-inline-start: 0;
+          position: absolute;
+        }
 
-            .logo-content {
-              align-items: center;
+        .navbar-link__sign-up {
+          border: 2px solid $tailwind-primary;
+          border-radius: 44px;
+          min-width: max-content;
+        }
+
+        .navbar-link.navbar-link__sign-up:hover {
+          @apply text-white;
+          background-color: $tailwind-primary;
+          border: 2px solid $tailwind-primary;
+          border-radius: 44px;
+        }
+
+        .navbar-link:hover {
+          @apply text-primary-dark;
+          border: none;
+        }
+
+        .navbar-dropdown-container {
+          display: flex;
+          margin-left: 0px;
+          border-top: 1px transparent;
+          margin-top: 7px;
+          width: auto;
+          .navbar-dropdown {
+            .navbar-dropdown-item-container {
               display: flex;
-              padding: 0;
+            }
+            .navbar-dropdown-item {
+              flex: 1 1 auto;
+              font-size: 0.75rem;
+            }
+          }
+        }
+
+        .navbar-mobile-menu-button {
+          @apply flex;
+          border: none;
+          margin: 2.75rem 0.5rem 0;
+          padding: 0 0.5rem 0.75rem;
+        }
+
+        .ui-icon svg rect {
+          fill: $tailwind-primary;
+        }
+      }
+
+      .navbar-logo {
+        @media (min-width: $header-desktop-min-size) {
+          padding: 48px 0 32px 0;
+        }
+
+        @screen xl {
+          padding: 48px 0 32px;
+        }
+
+        .logo {
+          background-color: initial;
+          box-shadow: none;
+          height: 100%;
+          margin: 0;
+          max-height: 15rem;
+          max-width: 100%;
+          padding: 0;
+          width: 100%;
+
+          .logo-content {
+            align-items: center;
+            display: flex;
+            padding: 0;
+          }
+
+          .logo__title {
+            @apply text-primary-dark;
+            @apply text-base;
+            letter-spacing: initial;
+            margin-left: 4px;
+            text-align: left;
+            text-transform: none;
+
+            @media (min-width: $header-desktop-min-size) {
+              @apply text-2xl;
+              margin-left: 8px;
             }
 
-            .logo__title {
-              @apply text-primary-dark;
-              @apply text-base;
-              letter-spacing: initial;
-              margin-left: 4px;
-              text-align: left;
-              text-transform: none;
-
-              @media (min-width: $header-desktop-min-size) {
-                @apply text-2xl;
-                margin-left: 8px;
-              }
-
-              @screen xl {
-                @apply text-2xl;
-              }
-            }
-
-            .logo__subtitle {
-              font-size: 0.625rem;
-              font-weight: 400;
-
-              @media (min-width: $header-desktop-min-size) {
-                @apply text-sm;
-              }
-            }
-
-            .logo__image {
-              height: 57px;
-              margin: -12px 0 0 12px;
-              // The header logo should allow for a larger maximum height than the default
-              // logo.
-              max-height: 5rem;
-
-              @media (min-width: $header-desktop-min-size) {
-                height: 77px;
-                // Negative margin to center around the shield
-                margin: -16px 0 0;
-                max-height: 6rem;
-              }
-
-              @screen xl {
-                max-height: 7rem;
-              }
+            @screen xl {
+              @apply text-2xl;
             }
           }
 
-          .navbar-custom-width {
-            align-items: initial;
-            display: initial;
-            flex-direction: initial;
-            justify-content: initial;
+          .logo__subtitle {
+            font-size: 0.625rem;
+            font-weight: 400;
+
+            @media (min-width: $header-desktop-min-size) {
+              @apply text-sm;
+            }
           }
+
+          .logo__image {
+            height: 57px;
+            margin: -12px 0 0 12px;
+            // The header logo should allow for a larger maximum height than the default
+            // logo.
+            max-height: 5rem;
+
+            @media (min-width: $header-desktop-min-size) {
+              height: 77px;
+              // Negative margin to center around the shield
+              margin: -16px 0 0;
+              max-height: 6rem;
+            }
+
+            @screen xl {
+              max-height: 7rem;
+            }
+          }
+        }
+
+        .navbar-custom-width {
+          align-items: initial;
+          display: initial;
+          flex-direction: initial;
+          justify-content: initial;
         }
       }
     }
-    .navbar-mobile-dropdown {
-      margin-bottom: 1.5rem;
-    }
-
-    .navbar-mobile-dropdown-container .navbar-mobile-dropdown .navbar-mobile-dropdown-item {
-      @screen md {
-        @apply text-primary;
-        font-size: 1.125rem;
-        font-weight: 700;
-        text-transform: none;
-      }
-    }
+  }
+  .navbar-mobile-dropdown {
+    margin-bottom: 1.5rem;
   }
 
-  .hero {
-    @apply font-bold;
-    @apply mx-2;
-    @apply mb-4;
-    @apply rounded-2xl;
-
-    @screen sm {
-      @apply mx-4;
-    }
-  }
-
-  .hero__title {
-    @apply text-3xl;
-    @apply text-primary-dark;
-    @apply tracking-normal;
-    @apply leading-tight;
-    @apply mb-5;
-
-    @screen sm {
-      @apply text-6xl;
-    }
-  }
-
-  .hero__inner {
-    // https://github.com/tailwindlabs/tailwindcss/issues/1692
-    background-color: rgba(255, 255, 255, 0.9);
-  }
-
-  .hero__subtitle {
-    @apply mb-5;
-    color: black;
-    font-size: unset;
-    font-weight: normal;
-    text-shadow: none;
-  }
-
-  .hero__button {
-    display: inline-block;
-    font-size: large;
-    max-width: 100%;
-    padding: 12px;
-    padding: 0.875rem 2.25rem;
-    width: auto;
-    margin-top: 1rem;
-    border-radius: 40px;
-
-    @screen sm {
-      margin-top: 0;
-    }
-  }
-
-  .hero__rentals-button {
-    color: black;
-    background-color: #ffbe42;
-
-    &:hover {
-      @apply bg-primary;
-      color: white;
-    }
-  }
-  .hero__finder-button {
-    color: var(--bloom-color-white);
-    background-color: var(--bloom-color-primary-dark);
-    &:hover {
-      color: var(--bloom-color-white);
-      box-shadow: 0 0 0 var(--bloom-s0_5) var(--bloom-color-primary-dark) inset;
-      background-color: var(--bloom-color-black);
-    }
-  }
-
-  .page-header__title {
-    font-size: 1.5rem;
-    font-weight: 700;
+  .navbar-mobile-dropdown-container .navbar-mobile-dropdown .navbar-mobile-dropdown-item {
     @screen md {
-      font-size: 1.75rem;
+      @apply text-primary;
+      font-size: 1.125rem;
+      font-weight: 700;
+      text-transform: none;
     }
   }
+}
 
-  .page-header__lead {
-    @apply mt-4;
+.hero {
+  @apply font-bold;
+  @apply mx-2;
+  @apply mb-4;
+  @apply rounded-2xl;
+
+  @screen sm {
+    @apply mx-4;
   }
+}
+
+.hero__title {
+  @apply text-3xl;
+  @apply text-primary-dark;
+  @apply tracking-normal;
+  @apply leading-tight;
+  @apply mb-5;
+
+  @screen sm {
+    @apply text-6xl;
+  }
+}
+
+.hero__inner {
+  // https://github.com/tailwindlabs/tailwindcss/issues/1692
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.hero__subtitle {
+  @apply mb-5;
+  color: black;
+  font-size: unset;
+  font-weight: normal;
+  text-shadow: none;
+}
+
+.hero__button {
+  display: inline-block;
+  font-size: large;
+  max-width: 100%;
+  padding: 12px;
+  padding: 0.875rem 2.25rem;
+  width: auto;
+  margin-top: 1rem;
+  border-radius: 40px;
+
+  @screen sm {
+    margin-top: 0;
+  }
+}
+
+.hero__rentals-button {
+  color: black;
+  background-color: #ffbe42;
+
+  &:hover {
+    @apply bg-primary;
+    color: white;
+  }
+}
+.hero__finder-button {
+  color: var(--bloom-color-white);
+  background-color: var(--bloom-color-primary-dark);
+  &:hover {
+    color: var(--bloom-color-white);
+    box-shadow: 0 0 0 var(--bloom-s0_5) var(--bloom-color-primary-dark) inset;
+    background-color: var(--bloom-color-black);
+  }
+}
+
+.page-header__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  @screen md {
+    font-size: 1.75rem;
+  }
+}
+
+.page-header__lead {
+  @apply mt-4;
 }

--- a/sites/public/styles/listings.scss
+++ b/sites/public/styles/listings.scss
@@ -1,148 +1,148 @@
-#__next {
-  .listings-title .page-header__group {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+/** Listings */
+
+.listings-title .page-header__group {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  @screen md {
+    flex-direction: row;
+  }
+}
+
+.listings-row_figure {
+  .image-card {
+    --default-background-color: transparent;
+  }
+
+  .image-card img {
+    border-radius: 24px;
+    height: 340px;
+    object-fit: cover;
+  }
+
+  .image-card__overlay {
+    background-image: none;
+    border-radius: 24px;
+  }
+
+  .image-card__figcaption {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 24px 0px 24px 24px;
+    bottom: 12px;
+    left: 12px;
+    margin-right: 48px;
+    max-width: 93%;
+    width: max-content;
 
     @screen md {
-      flex-direction: row;
+      bottom: 24px;
+      left: 24px;
+      max-width: 696px;
     }
+
+    @screen lg {
+      max-width: 440px;
+    }
+
+    .image-card__title {
+      @apply text-lg;
+      color: $tailwind-primary-darker;
+      font-weight: 700;
+      letter-spacing: initial;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-transform: none;
+      white-space: nowrap;
+
+      @screen md {
+        font-size: 1.5rem;
+      }
+    }
+
+    .image-card__subtitle {
+      @apply text-sm;
+      color: $tailwind-primary-darker;
+      letter-spacing: initial;
+      text-transform: none;
+
+      @screen md {
+        font-size: 0.875rem;
+      }
+    }
+  }
+}
+
+// Toggled off
+.latest-listings {
+  .listings-row_table,
+  .listings-row_footer_container {
+    display: none;
+  }
+
+  .listings-row {
+    margin: 0 15px;
+  }
+
+  .listings-row:hover {
+    opacity: 0.7;
+  }
+
+  .listings-row_content {
+    width: 100%;
+    @apply px-0;
   }
 
   .listings-row_figure {
-    .image-card {
-      --default-background-color: transparent;
-    }
+    padding: 0;
+  }
 
-    .image-card img {
-      border-radius: 24px;
+  .listings-row_figure {
+    width: 390px;
+
+    @screen md {
+      width: 497px;
+    }
+  }
+
+  .image-card img {
+    height: 258px;
+
+    @screen md {
       height: 340px;
-      object-fit: cover;
-    }
-
-    .image-card__overlay {
-      background-image: none;
-      border-radius: 24px;
-    }
-
-    .image-card__figcaption {
-      background: rgba(255, 255, 255, 0.9);
-      border-radius: 24px 0px 24px 24px;
-      bottom: 12px;
-      left: 12px;
-      margin-right: 48px;
-      max-width: 93%;
-      width: max-content;
-
-      @screen md {
-        bottom: 24px;
-        left: 24px;
-        max-width: 696px;
-      }
-
-      @screen lg {
-        max-width: 440px;
-      }
-
-      .image-card__title {
-        @apply text-lg;
-        color: $tailwind-primary-darker;
-        font-weight: 700;
-        letter-spacing: initial;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        text-transform: none;
-        white-space: nowrap;
-
-        @screen md {
-          font-size: 1.5rem;
-        }
-      }
-
-      .image-card__subtitle {
-        @apply text-sm;
-        color: $tailwind-primary-darker;
-        letter-spacing: initial;
-        text-transform: none;
-
-        @screen md {
-          font-size: 0.875rem;
-        }
-      }
     }
   }
+}
 
-  // Toggled off
-  .latest-listings {
-    .listings-row_table,
-    .listings-row_footer_container {
-      display: none;
-    }
-
-    .listings-row {
-      margin: 0 15px;
-    }
-
-    .listings-row:hover {
-      opacity: 0.7;
-    }
-
-    .listings-row_content {
-      width: 100%;
-      @apply px-0;
-    }
-
-    .listings-row_figure {
-      padding: 0;
-    }
-
-    .listings-row_figure {
-      width: 390px;
-
-      @screen md {
-        width: 497px;
-      }
-    }
-
-    .image-card img {
-      height: 258px;
-
-      @screen md {
-        height: 340px;
-      }
+.coming-soon-listings {
+  .listings-row_table,
+  .listings-row_footer_container {
+    display: none;
+  }
+  .listings-row {
+    @apply mt-0;
+    @apply mb-2;
+    @apply px-4;
+    flex: 1;
+    @screen lg {
+      display: block;
     }
   }
+  .listings-row_content {
+    width: 100%;
+    padding: 1rem 0 0 0;
+  }
 
-  .coming-soon-listings {
-    .listings-row_table,
-    .listings-row_footer_container {
-      display: none;
-    }
-    .listings-row {
-      @apply mt-0;
-      @apply mb-2;
-      @apply px-4;
-      flex: 1;
-      @screen lg {
-        display: block;
-      }
-    }
-    .listings-row_content {
-      width: 100%;
-      padding: 1rem 0 0 0;
-    }
-
-    .listings-row_figure {
-      width: 100%;
-      border-radius: 24px 24px 0 0;
-      padding: 0;
-    }
-    .image-card {
-      --default-background-color: transparent;
-    }
-    img {
-      border-radius: 24px 24px 0 0;
-    }
+  .listings-row_figure {
+    width: 100%;
+    border-radius: 24px 24px 0 0;
+    padding: 0;
+  }
+  .image-card {
+    --default-background-color: transparent;
+  }
+  img {
+    border-radius: 24px 24px 0 0;
   }
 }

--- a/sites/public/styles/overlays.scss
+++ b/sites/public/styles/overlays.scss
@@ -1,80 +1,80 @@
-#__next {
-  .modal {
-    border-radius: 0;
-    height: 100%;
-    max-height: 100vh;
-    max-width: initial;
-    min-width: 20rem;
-    width: 100%;
-    overflow-y: auto;
-    @screen md {
-      max-height: 80vh;
-      max-width: 32rem;
-    }
+/** Overlays */
 
-    .modal__title {
-      @apply text-lg;
-      @apply font-bold;
-      @screen sm {
-        @apply text-3xl font-bold;
-      }
-    }
+.modal {
+  border-radius: 0;
+  height: 100%;
+  max-height: 100vh;
+  max-width: initial;
+  min-width: 20rem;
+  width: 100%;
+  overflow-y: auto;
+  @screen md {
+    max-height: 80vh;
+    max-width: 32rem;
+  }
 
-    .modal__close svg {
-      fill: #5f6368;
-    }
-
-    .modal__inner {
-      padding: 1rem 1.5rem;
-
-      @screen md {
-        padding: 1rem 2.25rem;
-      }
-    }
-
-    .form-card__group {
-      margin: 0;
-      padding: 0;
-    }
-
-    .filter-section label,
-    .filter-header {
-      @apply text-base;
-      @apply font-bold;
-    }
-
-    .checkbox-filter-group {
-      display: flex;
-      flex-wrap: wrap;
-      margin: 0.5rem 0 1rem;
-
-      .field {
-        flex: 0 0 50%;
-        margin-bottom: 0.25rem;
-      }
-    }
-
-    .rent-range {
-      margin: 0.5rem 0 1.25rem;
-    }
-
-    .rent-range .field {
-      margin: 0;
-    }
-    .rent-range .control {
-      margin: 0;
-    }
-
-    button.button {
-      padding: 1rem 3rem;
+  .modal__title {
+    @apply text-lg;
+    @apply font-bold;
+    @screen sm {
+      @apply text-3xl font-bold;
     }
   }
 
-  .media-modal {
-    border: none;
-    max-width: none;
-    @media (min-width: $screen-md) {
-      width: 48rem;
+  .modal__close svg {
+    fill: #5f6368;
+  }
+
+  .modal__inner {
+    padding: 1rem 1.5rem;
+
+    @screen md {
+      padding: 1rem 2.25rem;
     }
+  }
+
+  .form-card__group {
+    margin: 0;
+    padding: 0;
+  }
+
+  .filter-section label,
+  .filter-header {
+    @apply text-base;
+    @apply font-bold;
+  }
+
+  .checkbox-filter-group {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0.5rem 0 1rem;
+
+    .field {
+      flex: 0 0 50%;
+      margin-bottom: 0.25rem;
+    }
+  }
+
+  .rent-range {
+    margin: 0.5rem 0 1.25rem;
+  }
+
+  .rent-range .field {
+    margin: 0;
+  }
+  .rent-range .control {
+    margin: 0;
+  }
+
+  button.button {
+    padding: 1rem 3rem;
+  }
+}
+
+.media-modal {
+  border: none;
+  max-width: none;
+  @media (min-width: $screen-md) {
+    width: 48rem;
   }
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -1,66 +1,115 @@
 /* Overrides the default ui-components styles with Detroit-specific styles. */
 @import url("https://fonts.googleapis.com/css?family=Montserrat:400,600,700");
+#__next {
+  // Certain SVG icons should be green.
+  // NOTE: might not need, could delete. -JW
+  .filled-icon .ui-icon svg {
+    fill: $tailwind-primary-darker;
+  }
 
-// Certain SVG icons should be green.
-// NOTE: might not need, could delete. -JW
-.filled-icon .ui-icon svg {
-  fill: $tailwind-primary-darker;
-}
+  $header-desktop-min-size: 1024px;
 
-$header-desktop-min-size: 1024px;
+  @import "blocks.scss";
+  @import "forms.scss";
+  @import "footers.scss";
+  @import "forms.scss";
+  @import "headers.scss";
+  @import "listings.scss";
+  @import "overlays.scss";
 
-@import "blocks.scss";
-@import "forms.scss";
-@import "footers.scss";
-@import "forms.scss";
-@import "headers.scss";
-@import "listings.scss";
-@import "overlays.scss";
+  /* One-offs: */
 
-/* One-offs: */
+  .loading-overlay__spinner circle {
+    stroke: $tailwind-primary;
+  }
 
-.loading-overlay__spinner circle {
-  stroke: $tailwind-primary;
-}
+  // Center the front page.
+  .homepage-extra {
+    @apply text-center;
+    @apply text-base;
+    @apply mb-10;
+  }
 
-// Center the front page.
-.homepage-extra {
-  @apply text-center;
-  @apply text-base;
-  @apply mb-10;
-}
-
-// Fix rtl border between action blocks on the homepage.
-.homepage-extra {
-  .action-blocks {
-    @screen md {
-      > :nth-child(2) {
-        border-left-width: 0;
-        border-inline-width: 1px;
-      }
-      .action-block__header {
-        font-size: (var(--bloom-font-size-base-alt));
+  // Fix rtl border between action blocks on the homepage.
+  .homepage-extra {
+    .action-blocks {
+      @screen md {
+        > :nth-child(2) {
+          border-left-width: 0;
+          border-inline-width: 1px;
+        }
+        .action-block__header {
+          font-size: (var(--bloom-font-size-base-alt));
+        }
       }
     }
   }
-}
 
-.eligibility-disclaimer-header {
-  padding: 20px 80px;
-}
+  .eligibility-disclaimer-header {
+    padding: 20px 80px;
+  }
 
-.eligibility-disclaimer-submit-container {
-  padding-bottom: 40px;
-  text-align: center;
-}
+  .eligibility-disclaimer-submit-container {
+    padding-bottom: 40px;
+    text-align: center;
+  }
 
-.accessibility-eligibility-selector {
-  column-count: 2;
-  font-size: small;
-  margin-bottom: 20px;
-  margin-top: 10px;
-  .field {
-    margin-bottom: 3.5px;
+  .accessibility-eligibility-selector {
+    column-count: 2;
+    font-size: small;
+    margin-bottom: 20px;
+    margin-top: 10px;
+    .field {
+      margin-bottom: 3.5px;
+    }
+  }
+
+  .button {
+    --normal-rounded: 60px;
+    --normal-padding: 0.5rem 1rem;
+    --normal-font-size: var(--bloom-font-size-base);
+    --label-letter-spacing: normal;
+    --label-transform: none;
+    &:hover {
+      svg {
+        fill: var(--bloom-color-white);
+      }
+    }
+    .ui-icon {
+      &.button__icon {
+        margin: 0 0.5rem 0 0;
+      }
+    }
+  }
+
+  .action-block {
+    .action-block__actions .button {
+      @media (max-width: 640px) {
+        @apply text-sm;
+      }
+    }
+  }
+
+  // These will be removed as we sync the remaining components
+  .aside-block {
+    svg {
+      fill: var(--bloom-color-primary);
+    }
+  }
+
+  .header-badge {
+    svg {
+      width: 3rem;
+      height: 3rem;
+      @media (max-width: 640px) {
+        width: 2.5rem;
+        height: 2.5rem;
+      }
+    }
+  }
+
+  .alert-box.primary {
+    background-color: var(--bloom-color-gray-400);
   }
 }
 
@@ -87,52 +136,4 @@ $header-desktop-min-size: 1024px;
   --primary-appearance-hover-border-color: var(--bloom-color-primary);
   --outlined-appearance-hover-background-color: var(--bloom-color-primary);
   --outlined-appearance-hover-border-color: var(--bloom-color-primary);
-}
-
-.button {
-  --normal-rounded: 60px;
-  --normal-padding: 0.5rem 1rem;
-  --normal-font-size: var(--bloom-font-size-base);
-  --label-letter-spacing: normal;
-  --label-transform: none;
-  &:hover {
-    svg {
-      fill: var(--bloom-color-white);
-    }
-  }
-  .ui-icon {
-    &.button__icon {
-      margin: 0 0.5rem 0 0;
-    }
-  }
-}
-
-.action-block {
-  .action-block__actions .button {
-    @media (max-width: 640px) {
-      @apply text-sm;
-    }
-  }
-}
-
-// These will be removed as we sync the remaining components
-.aside-block {
-  svg {
-    fill: var(--bloom-color-primary);
-  }
-}
-
-.header-badge {
-  svg {
-    width: 3rem;
-    height: 3rem;
-    @media (max-width: 640px) {
-      width: 2.5rem;
-      height: 2.5rem;
-    }
-  }
-}
-
-.alert-box.primary {
-  background-color: var(--bloom-color-gray-400);
 }

--- a/sites/public/tailwind.config.js
+++ b/sites/public/tailwind.config.js
@@ -48,6 +48,12 @@ module.exports = {
       "./layouts/**/*.tsx",
       "../../detroit-ui-components/src/**/*.tsx",
     ],
-    safelist: [/grid-cols-/],
+    safelist: [
+      { pattern: /grid-cols-/ },
+      {
+        pattern: /col-span-/,
+        variants: ["md"],
+      },
+    ],
   },
 }

--- a/sites/public/tailwind.config.js
+++ b/sites/public/tailwind.config.js
@@ -48,12 +48,6 @@ module.exports = {
       "./layouts/**/*.tsx",
       "../../detroit-ui-components/src/**/*.tsx",
     ],
-    safelist: [
-      { pattern: /grid-cols-/ },
-      {
-        pattern: /col-span-/,
-        variants: ["md"],
-      },
-    ],
+    safelist: [/grid-cols-/, /md:col-span-/],
   },
 }


### PR DESCRIPTION
I'd recommend reviewing with `hide whitespace`, very few lines changed.

<img width="1029" alt="Screenshot 2023-02-16 at 2 21 00 PM" src="https://user-images.githubusercontent.com/65367387/219466010-046c7259-3ca3-487b-aa2c-56632cdf8773.png">

We're seeing this grid issue locally but not in Netlify environments. The issue was that one class `md:grid-cols-3` was in the DOM but wasn't actually being applied.

The class is created dynamically like so: `if (props.span) gridCellClasses.push('md:col-span-${props.span}')`

I first found this [StackOverflow post](https://stackoverflow.com/questions/71937890/tailwind-css-classes-show-up-in-the-dom-but-the-styles-are-not-being-applied) which did solve the issue. It indicates that Tailwind scans for used class names, and since we don't explicitly have `md:grid-cols-3` as a string, but with the var in the string literal, it wouldn't be added.

I think the core of that issue is that UIC has `purge: false` in its tailwind config, but Detroit at root has purge set to `process.env.NODE_ENV !== "development"` - so locally where it is working we were still getting all styles but in builds we are purging and that's why this class wasn't working. Pulling out UIC likely caused this issue, since this was fine before in Netlify environments even when the public site purging was on. On this branch if I turn purging off, it works.

For the time being I haven't touched the purge settings and just added the needed class to the safelist, but we should have purging on in UIC. I did a scan of Detroit and didn't find another place we are breaking up a tailwind class name.

The shuffling of the #next id is just cleanup that helped me with readability / understanding class priority order.