### PR TITLE
feat: focus title on modal open

### DIFF
--- a/detroit-ui-components/src/overlays/Modal.tsx
+++ b/detroit-ui-components/src/overlays/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import "./Modal.scss"
 import { Icon, IconFillColors } from "../icons/Icon"
 import { Overlay, OverlayProps } from "./Overlay"
@@ -21,12 +21,19 @@ export interface ModalProps extends Omit<OverlayProps, "children"> {
 }
 
 const ModalHeader = (props: { title: string; uniqueId?: string; className?: string }) => {
+  const modalHeader = useRef<HTMLHeadingElement>(null)
+  useEffect(() => {
+    if (modalHeader.current && props.title) {
+      modalHeader?.current?.focus()
+    }
+  }, [props.title])
+
   const classNames = ["modal__title"]
   if (props.className) classNames.push(props.className)
   return (
     <>
       <header className="modal__header">
-        <h1 className={classNames.join(" ")} id={props.uniqueId}>
+        <h1 ref={modalHeader} tabIndex={-1} className={classNames.join(" ")}>
           {props.title}
         </h1>
       </header>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1535

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The goal was to better handle focus after opening modal ( in this case video pop-up).
Used solution from previous PR #1549. But with modal it's a bit off, because reader seem to read first element and then `and x more`, and then focused heading, so it's sth like `, and 2 more, dialog, Detroit Home Connect: What is Affordable Housing?`.
- some modals i saw used pattern `heading -> and x more -> focused item`, in our case heading is nested so it probably need some id and some aria prop, and youtube player takes focus too fast for some reason, so this solution might be tricky.
- There is request `Should alert something like “video player expanded”` i thought of adding this to aria-label of `h1` like `video player expanded - title`. Or adding empty p tag with aria label  “video player expanded” so it will read `video player expanded, and x more, dialog, title`.

## How Can This Be Tested/Reviewed?

go to `/housing-basics` open card having reader on.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
