### PR TITLE
fix: custom focus management

### DIFF
--- a/sites/public/src/pages/finder.tsx
+++ b/sites/public/src/pages/finder.tsx
@@ -14,7 +14,7 @@ import {
 import axios from "axios"
 import router from "next/router"
 
-import React, { useEffect, useRef, useState } from "react"
+import React, { forwardRef, useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import Layout from "../layouts/application"
 import FinderDisclaimer from "../components/finder/FinderDisclaimer"
@@ -28,6 +28,12 @@ interface FinderField {
   type?: string
 }
 
+interface ProgressHeaderProps {
+  isDisclaimer: boolean
+  sectionNumber: number
+  stepLabels: string[]
+}
+
 export interface FinderQuestion {
   formSection: string
   fieldGroupName: string
@@ -37,12 +43,47 @@ export interface FinderQuestion {
   subtitle: string
 }
 
+const ProgressHeader = forwardRef((props: ProgressHeaderProps, ref: any) => {
+  console.log(ref)
+  return (
+    <div className="flex flex-col w-full pb-8 px-2 lg:px-0 sm:pb-0">
+      <div className="flex flex-row flex-wrap justify-between gap-y-4 gap-x-0.5">
+        <h1 className="text-base md:text-lg capitalize font-bold">
+          {t("listingFilters.buttonTitleExtended")}
+        </h1>
+        <div tabIndex={-1} ref={ref}>
+          {!props.isDisclaimer && (
+            <StepHeader
+              currentStep={props.sectionNumber}
+              totalSteps={3}
+              stepPreposition={t("finder.progress.stepPreposition")}
+              stepLabeling={props.stepLabels}
+              priority={2}
+            />
+          )}
+        </div>
+      </div>
+      <div className="hidden sm:block">
+        <ProgressNav
+          currentPageSection={props.sectionNumber}
+          completedSections={props.sectionNumber - 1}
+          labels={props.stepLabels}
+          mounted={true}
+          style="bar"
+          removeSrHeader
+        />
+      </div>
+    </div>
+  )
+})
+
 const Finder = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, handleSubmit, trigger, errors, watch } = useForm()
   const [questionIndex, setQuestionIndex] = useState<number>(0)
   const [formData, setFormData] = useState<FinderQuestion[]>([])
   const [isDisclaimer, setIsDisclaimer] = useState<boolean>(false)
+  const finderSectionQuestion = useRef(null)
   const finderSectionHeader = useRef(null)
   const minRent = watch("minRent")
   const maxRent = watch("maxRent")
@@ -190,37 +231,6 @@ const Finder = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const ProgressHeader = () => {
-    return (
-      <div className="flex flex-col w-full pb-8 px-2 lg:px-0 sm:pb-0">
-        <div className="flex flex-row flex-wrap justify-between gap-y-4 gap-x-0.5">
-          <h1 className="text-base md:text-lg capitalize font-bold">
-            {t("listingFilters.buttonTitleExtended")}
-          </h1>
-          {!isDisclaimer && (
-            <StepHeader
-              currentStep={sectionNumber}
-              totalSteps={3}
-              stepPreposition={t("finder.progress.stepPreposition")}
-              stepLabeling={stepLabels}
-              priority={2}
-            />
-          )}
-        </div>
-        <div className="hidden sm:block">
-          <ProgressNav
-            currentPageSection={sectionNumber}
-            completedSections={sectionNumber - 1}
-            labels={stepLabels}
-            mounted={true}
-            style="bar"
-            removeSrHeader
-          />
-        </div>
-      </div>
-    )
-  }
-
   const nextQuestion = () => {
     if (!Object.keys(errors).length) {
       const formCopy = [...formData]
@@ -236,35 +246,55 @@ const Finder = () => {
         })
       }
       setFormData(formCopy)
-      if (questionIndex >= formData.length - 1) setIsDisclaimer(true)
-      setQuestionIndex(questionIndex + 1)
-      finderSectionHeader.current.focus()
+      if (questionIndex >= formData.length - 1) {
+        setIsDisclaimer(true)
+        setQuestionIndex(questionIndex + 1)
+        finderSectionQuestion.current.focus()
+      } else if (
+        formData[questionIndex]?.formSection !== formData[questionIndex + 1]?.formSection
+      ) {
+        setQuestionIndex(questionIndex + 1)
+        finderSectionHeader.current.focus()
+      } else {
+        setQuestionIndex(questionIndex + 1)
+        finderSectionQuestion.current.focus()
+      }
     }
   }
   const previousQuestion = () => {
     setIsDisclaimer(false)
-    setQuestionIndex(questionIndex - 1)
-    finderSectionHeader.current.focus()
+    if (formData[questionIndex]?.formSection !== formData[questionIndex - 1]?.formSection) {
+      setQuestionIndex(questionIndex - 1)
+      finderSectionHeader.current.focus()
+    } else {
+      setQuestionIndex(questionIndex - 1)
+      finderSectionQuestion.current.focus()
+    }
   }
 
   const skipToListings = () => {
     setIsDisclaimer(true)
     setQuestionIndex(formData.length)
-    finderSectionHeader.current.focus()
+    finderSectionQuestion.current.focus()
   }
 
   return (
     <Layout>
       <Form onSubmit={handleSubmit(onSubmit)} className="bg-gray-300 border-t border-gray-450">
         <div className="md:mb-8 mt-8 mx-auto max-w-5xl">
-          <ProgressHeader />
+          <ProgressHeader
+            isDisclaimer={isDisclaimer}
+            sectionNumber={sectionNumber}
+            stepLabels={stepLabels}
+            ref={finderSectionHeader}
+          />
           <Card className="finder-card">
             {formData?.length > 0 && (
               <div>
                 <Card.Header>
                   {/* Deconstructed header group to support ref */}
                   <hgroup role="group">
-                    <h3 tabIndex={-1} ref={finderSectionHeader}>
+                    <h3 tabIndex={-1} ref={finderSectionQuestion}>
                       {!isDisclaimer ? activeQuestion.question : t("finder.disclaimer.header")}
                     </h3>
                     <p aria-roledescription="subtitle">

--- a/sites/public/src/pages/finder.tsx
+++ b/sites/public/src/pages/finder.tsx
@@ -43,39 +43,41 @@ export interface FinderQuestion {
   subtitle: string
 }
 
-const ProgressHeader = forwardRef((props: ProgressHeaderProps, ref: any) => {
-  console.log(ref)
-  return (
-    <div className="flex flex-col w-full pb-8 px-2 lg:px-0 sm:pb-0">
-      <div className="flex flex-row flex-wrap justify-between gap-y-4 gap-x-0.5">
-        <h1 className="text-base md:text-lg capitalize font-bold">
-          {t("listingFilters.buttonTitleExtended")}
-        </h1>
-        <div tabIndex={-1} ref={ref}>
-          {!props.isDisclaimer && (
-            <StepHeader
-              currentStep={props.sectionNumber}
-              totalSteps={3}
-              stepPreposition={t("finder.progress.stepPreposition")}
-              stepLabeling={props.stepLabels}
-              priority={2}
-            />
-          )}
+const ProgressHeader = forwardRef(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (props: ProgressHeaderProps, ref: React.MutableRefObject<any>) => {
+    return (
+      <div className="flex flex-col w-full pb-8 px-2 lg:px-0 sm:pb-0">
+        <div className="flex flex-row flex-wrap justify-between gap-y-4 gap-x-0.5">
+          <h1 className="text-base md:text-lg capitalize font-bold">
+            {t("listingFilters.buttonTitleExtended")}
+          </h1>
+          <div tabIndex={-1} ref={ref}>
+            {!props.isDisclaimer && (
+              <StepHeader
+                currentStep={props.sectionNumber}
+                totalSteps={3}
+                stepPreposition={t("finder.progress.stepPreposition")}
+                stepLabeling={props.stepLabels}
+                priority={2}
+              />
+            )}
+          </div>
+        </div>
+        <div className="hidden sm:block">
+          <ProgressNav
+            currentPageSection={props.sectionNumber}
+            completedSections={props.sectionNumber - 1}
+            labels={props.stepLabels}
+            mounted={true}
+            style="bar"
+            removeSrHeader
+          />
         </div>
       </div>
-      <div className="hidden sm:block">
-        <ProgressNav
-          currentPageSection={props.sectionNumber}
-          completedSections={props.sectionNumber - 1}
-          labels={props.stepLabels}
-          mounted={true}
-          style="bar"
-          removeSrHeader
-        />
-      </div>
-    </div>
-  )
-})
+    )
+  }
+)
 
 const Finder = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -246,16 +248,19 @@ const Finder = () => {
         })
       }
       setFormData(formCopy)
+      // check for disclaimer case
       if (questionIndex >= formData.length - 1) {
         setIsDisclaimer(true)
         setQuestionIndex(questionIndex + 1)
         finderSectionQuestion.current.focus()
-      } else if (
-        formData[questionIndex]?.formSection !== formData[questionIndex + 1]?.formSection
-      ) {
+      }
+      // set focus on stepheader if section change
+      else if (formData[questionIndex]?.formSection !== formData[questionIndex + 1]?.formSection) {
         setQuestionIndex(questionIndex + 1)
         finderSectionHeader.current.focus()
-      } else {
+      }
+      // otherwise set focus on question
+      else {
         setQuestionIndex(questionIndex + 1)
         finderSectionQuestion.current.focus()
       }
@@ -263,10 +268,13 @@ const Finder = () => {
   }
   const previousQuestion = () => {
     setIsDisclaimer(false)
+    // set focus on stepheader if section change
     if (formData[questionIndex]?.formSection !== formData[questionIndex - 1]?.formSection) {
       setQuestionIndex(questionIndex - 1)
       finderSectionHeader.current.focus()
-    } else {
+    }
+    // otherwise set focus on question
+    else {
       setQuestionIndex(questionIndex - 1)
       finderSectionQuestion.current.focus()
     }


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1562 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR tailors the focus behavior on the rental finder form to better communicate changes in the form section. Now when clicking next or previous results in a change in form section, the focus should land on the step header rather than the question text. If navigating between questions within the same section, the focus still lands on the question text.

## How Can This Be Tested/Reviewed?

This can be tested by going through the rental finder form with screen reader enabled and noticing where the focus lands after clicking next or previous. This behavior should also be verified on NVDA.
 
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
