### PR TITLE
fix: description grid misalignment

### DIFF
--- a/detroit-ui-components/src/text/Description.scss
+++ b/detroit-ui-components/src/text/Description.scss
@@ -25,7 +25,7 @@
     color: var(--title-text-color);
     margin-bottom: var(--bloom-s1);
     clear: left;
-    height: max-content;
+    height: auto;
     width: 100%;
 
     @media (min-width: $screen-md) {

--- a/detroit-ui-components/src/text/Description.scss
+++ b/detroit-ui-components/src/text/Description.scss
@@ -1,65 +1,55 @@
 @import "../global/mixins.scss";
 
-.description__container {
-  @apply w-full;
-  @apply flex;
-  @apply flex-col;
-  @apply mb-3;
-  @screen md {
-    @apply flex-row;
-  }
-}
-
-// Description
-.description__title {
-  @apply font-serif;
-  @apply text-xl;
-}
-
-.description__body {
-  @apply mb-4;
-  @apply flex;
-  @apply items-center;
-
-  @screen md {
-    padding-top: 0.4em;
-  }
-}
-
-// Data lists
+// Description grid
 .column-definition-list {
   @include clearfix;
 
-  .description__title {
-    @apply text-lg;
-    @apply text-gray-800;
-    clear: left;
-    width: 170px;
-    min-width: 170px;
+  --title-font-family: var(--bloom-font-serif);
+  --title-font-size-desktop: var(--bloom-font-size-xl);
+  --title-font-size-mobile: var(--bloom-font-size-lg);
+  --title-text-color: var(--bloom-color-gray-800);
+  --body-font-size: var(--bloom-font-size-sm);
+  --border-color: var(--bloom-color-gray-450);
+  --last-row-grid: span 2 / span 2;
 
-    @screen md {
-      @apply pl-4;
-      @apply border-l-2;
-      @apply border-gray-450;
-      @apply float-left;
-      @apply pr-3;
-      margin-top: 0.15rem;
+  @media (min-width: $screen-md) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: var(--bloom-s4);
+    grid-row-gap: 0.15rem;
+  }
+
+  .description__title {
+    font-family: var(--title-font-family);
+    font-size: var(--title-font-size-mobile);
+    color: var(--title-text-color);
+    margin-bottom: var(--bloom-s1);
+    clear: left;
+    height: max-content;
+    width: 100%;
+
+    @media (min-width: $screen-md) {
+      padding-left: var(--bloom-s4);
+      border-left: 2px solid var(--border-color);
+      float: left;
+      margin-bottom: var(--bloom-s3);
+      font-size: var(--title-font-size-desktop);
     }
   }
 
   .description__body {
-    @apply text-tiny;
-    @apply mb-5;
-    @apply ml-2;
+    font-size: var(--body-font-size);
+    margin-bottom: var(--bloom-s5);
+    width: 100%;
 
-    @screen md {
-      @apply mb-0;
-      @apply float-left;
-      @apply w-2/3;
-    }
+    @media (min-width: $screen-md) {
+      margin-bottom: 0;
+      float: left;
+      padding-top: 0.4em;
 
-    &:last-of-type {
-      @apply w-full;
+      &:last-of-type {
+        grid-column: var(--last-row-grid);
+      }
     }
   }
 }

--- a/detroit-ui-components/src/text/Description.tsx
+++ b/detroit-ui-components/src/text/Description.tsx
@@ -5,23 +5,27 @@ import Markdown from "markdown-to-jsx"
 export interface DescriptionProps {
   term: string
   description: string | React.ReactNode
+  dtClassName?: string
   markdown?: boolean
 }
 
 export const Description = (props: DescriptionProps) => {
+  const dtClasses = ["description__body"]
+  if (props.dtClassName) dtClasses.push(props.dtClassName)
+
   return (
-    <div className={"description__container"}>
-      <dd className="description__title">{props.term}</dd>
+    <>
+      <dt className="description__title">{props.term}</dt>
       {props.markdown ? (
-        <dt className="description__body">
+        <dd className={dtClasses.join(" ")}>
           <Markdown
             options={{ disableParsingRawHTML: true }}
             children={props.description as string}
           />
-        </dt>
+        </dd>
       ) : (
-        <dt className="description__body">{props.description}</dt>
+        <dd className={dtClasses.join(" ")}>{props.description}</dd>
       )}
-    </div>
+    </>
   )
 }

--- a/sites/public/styles/listings.scss
+++ b/sites/public/styles/listings.scss
@@ -150,4 +150,5 @@
 .column-definition-list {
   --body-font-size: var(--bloom-font-size-tiny);
   --last-row-grid: auto;
+  --title-font-size-desktop: var(--bloom-font-size-lg);
 }

--- a/sites/public/styles/listings.scss
+++ b/sites/public/styles/listings.scss
@@ -146,3 +146,8 @@
     border-radius: 24px 24px 0 0;
   }
 }
+
+.column-definition-list {
+  --body-font-size: var(--bloom-font-size-tiny);
+  --last-row-grid: auto;
+}


### PR DESCRIPTION
[Slack thread
](https://exygy.slack.com/archives/C02G1S19QA2/p1678736662433509)
Sort of an unusual way to tackle this one, but the work to align the Description component is already in [PR in UIC](https://github.com/bloom-housing/ui-components/pull/84). This copy/pastas that locally, and adds a few expected Detroit overrides.

Once the Description PR goes into UIC we could remove this locally.