### PR TITLE
fix: change min/max rent inputs from number to text with only numbers

### DIFF
--- a/detroit-ui-components/src/forms/Field.tsx
+++ b/detroit-ui-components/src/forms/Field.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React, { ChangeEvent, useMemo } from "react"
 import { ErrorMessage } from "@bloom-housing/ui-components"
 import { UseFormMethods, RegisterOptions } from "react-hook-form"
 
@@ -59,20 +59,21 @@ const Field = (props: FieldProps) => {
   if (props.bordered && (props.type === "radio" || props.type === "checkbox"))
     controlClasses.push("field-border")
 
-  const formatValue = () => {
-    if (props.getValues && props.setValue) {
-      const currencyValue = props.getValues(props.name)
-      const numericIncome = parseFloat(currencyValue)
-      if (!isNaN(numericIncome)) {
-        props.setValue(props.name, numericIncome.toFixed(2))
-      }
+  const filterNumbers = (e: ChangeEvent<HTMLInputElement>) => {
+    if (props.setValue) {
+      props.setValue(props.name, e.target.value.replace(/[a-z]|[A-Z]/g, "").match(/^\d*\.?\d?\d?/g))
     }
   }
 
   let inputProps = { ...props.inputProps }
-  if (props.type === "currency") inputProps = { ...inputProps, step: 0.01, onBlur: formatValue }
+  if (props.type === "currency") {
+    inputProps = {
+      ...inputProps,
+      onChange: filterNumbers,
+    }
+  }
 
-  const type = (props.type === "currency" && "number") || props.type || "text"
+  const type = (props.type === "currency" && "text") || props.type || "text"
   const isRadioOrCheckbox = ["radio", "checkbox"].includes(type)
 
   const label = useMemo(() => {

--- a/sites/public/src/components/filters/FilterForm.tsx
+++ b/sites/public/src/components/filters/FilterForm.tsx
@@ -118,7 +118,16 @@ const FilterForm = (props: FilterFormProps) => {
   // This is causing a linting issue with unbound-method, see issue:
   // https://github.com/react-hook-form/react-hook-form/issues/2887
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { handleSubmit, errors, register, reset, trigger, watch: formWatch } = useForm()
+  const {
+    handleSubmit,
+    errors,
+    register,
+    reset,
+    trigger,
+    watch: formWatch,
+    setValue,
+    getValues,
+  } = useForm()
   const minRent = formWatch("minRent")
   const maxRent = formWatch("maxRent")
 
@@ -247,10 +256,12 @@ const FilterForm = (props: FilterFormProps) => {
             <Field
               id={"minRent"}
               name={FrontendListingFilterStateKeys.minRent}
-              type="number"
+              type="currency"
               placeholder={t("publicFilter.rentRangeMin")}
               label={t("publicFilter.rentRangeMinReader")}
               register={register}
+              setValue={setValue}
+              getValues={getValues}
               prepend={"$"}
               defaultValue={localFilterState?.minRent}
               error={errors?.minRent !== undefined}
@@ -273,11 +284,13 @@ const FilterForm = (props: FilterFormProps) => {
           <GridCell span={1}>
             <Field
               id={"maxRent"}
-              type="number"
+              type="currency"
               name={FrontendListingFilterStateKeys.maxRent}
               placeholder={t("publicFilter.rentRangeMax")}
               label={t("publicFilter.rentRangeMaxReader")}
               register={register}
+              setValue={setValue}
+              getValues={getValues}
               prepend={"$"}
               defaultValue={localFilterState?.maxRent}
               error={errors?.maxRent !== undefined}

--- a/sites/public/src/components/finder/FinderRentalCosts.tsx
+++ b/sites/public/src/components/finder/FinderRentalCosts.tsx
@@ -12,6 +12,8 @@ const FinderRentalCosts = (props: {
   trigger: UseFormMethods["trigger"]
   minRent: number
   maxRent: number
+  getValues?: UseFormMethods["getValues"]
+  setValue?: UseFormMethods["setValue"]
 }) => {
   const dollarSign = useRouter().locale !== "ar"
   const numericFields = props.activeQuestion?.fields.filter((field) => field.type === "number")
@@ -26,11 +28,13 @@ const FinderRentalCosts = (props: {
             <Field
               id={field.label}
               name={FrontendListingFilterStateKeys[field.label]}
-              type="number"
+              type="currency"
               placeholder={t(`finder.rentalCosts.${isMin ? "min" : "max"}Placeholder`)}
               label={field.translation}
               ariaLabel={t(`publicFilter.rentRange${isMin ? "Min" : "Max"}Reader`)}
               register={props.register}
+              setValue={props.setValue}
+              getValues={props.getValues}
               prepend={dollarSign && "$"}
               defaultValue={typeof field?.value != "boolean" && field?.value}
               error={

--- a/sites/public/src/pages/finder.tsx
+++ b/sites/public/src/pages/finder.tsx
@@ -81,7 +81,7 @@ const ProgressHeader = forwardRef(
 
 const Finder = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, trigger, errors, watch } = useForm()
+  const { register, handleSubmit, trigger, errors, watch, setValue, getValues } = useForm()
   const [questionIndex, setQuestionIndex] = useState<number>(0)
   const [formData, setFormData] = useState<FinderQuestion[]>([])
   const [isDisclaimer, setIsDisclaimer] = useState<boolean>(false)
@@ -324,6 +324,8 @@ const Finder = () => {
                           trigger={trigger}
                           minRent={minRent}
                           maxRent={maxRent}
+                          setValue={setValue}
+                          getValues={getValues}
                         />
                       )}
                     </>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1563 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Changed input type from number to text, but restricted signs to numbers. This way we don't have scrolling, and screen reader announces it as `text field` which seem more reasonable than `stepper`.

## How Can This Be Tested/Reviewed?

Go to `/listings` -> open filters, using screen reader focus on min / max rent fields -> they should act as text field, but accept only numbers. Also scrolling inside field shouldn't change value.
Do the same for min/max rent fields in `/finder`

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
