### PR TITLE
fix: user export fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ storybook-static
 # Cypress test output videos
 **/cypress/videos
 **/cypress/screenshots
+**/cypress/downloads
 
 # Complied Typescript
 dist

--- a/backend/core/src/auth/controllers/user.controller.ts
+++ b/backend/core/src/auth/controllers/user.controller.ts
@@ -164,7 +164,7 @@ export class UserController {
     const users = await this.userService.list(
       {
         page: 1,
-        limit: "all",
+        limit: 300,
         filter: [
           {
             isPortalUser: true,

--- a/detroit-ui-components/src/locales/general.json
+++ b/detroit-ui-components/src/locales/general.json
@@ -833,7 +833,6 @@
   "listings.dueDateQuestion": "Is there an application due date?",
   "listings.editPreferences": "Edit Preferences",
   "listings.enterLotteryForWaitlist": "Submit an application for an open slot on the waitlist for %{units} units.",
-  "listings.exportSuccess": "The file has been exported",
   "listings.firstComeFirstServe": "First come first serve",
   "listings.forIncomeCalculations": "To determine your eligibility for this property, choose your household size (include yourself in that calculation). For each type of unit, your household cannot make more than the income limit shown below.",
   "listings.forIncomeCalculationsBMR": "Income calculations are based on unit type",

--- a/sites/partners/__tests__/pages/users/index.test.tsx
+++ b/sites/partners/__tests__/pages/users/index.test.tsx
@@ -113,7 +113,7 @@ describe("users", () => {
     expect(getByText("Export to CSV")).toBeInTheDocument()
     fireEvent.click(getByText("Export to CSV"))
     jest.clearAllTimers()
-    const successMessage = await findByText("The File has been exported")
+    const successMessage = await findByText("The file has been exported")
     expect(successMessage).toBeInTheDocument()
   })
 

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -438,7 +438,7 @@ const useCsvExport = (endpoint: () => Promise<string>, fileName: string) => {
       fileLink.href = URL.createObjectURL(blob)
       fileLink.click()
       setCsvExportSuccess(true)
-      setSiteAlertMessage(t("users.exportSuccess"), "success")
+      setSiteAlertMessage(t("t.exportSuccess"), "success")
     } catch (err) {
       setCsvExportError(true)
     }
@@ -480,7 +480,7 @@ export const useListingZip = () => {
         fileLink.click()
       })
       setZipCompleted(true)
-      setSiteAlertMessage(t("users.exportSuccess"), "success")
+      setSiteAlertMessage(t("t.exportSuccess"), "success")
     } catch (err) {
       setZipExportError(true)
     }

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -14,6 +14,7 @@ import {
 } from "@bloom-housing/backend-core/types"
 import dayjs from "dayjs"
 import JSZip from "jszip"
+import { setSiteAlertMessage, t } from "@bloom-housing/ui-components"
 
 interface PaginationProps {
   page?: number
@@ -437,6 +438,7 @@ const useCsvExport = (endpoint: () => Promise<string>, fileName: string) => {
       fileLink.href = URL.createObjectURL(blob)
       fileLink.click()
       setCsvExportSuccess(true)
+      setSiteAlertMessage(t("users.exportSuccess"), "success")
     } catch (err) {
       setCsvExportError(true)
     }
@@ -478,6 +480,7 @@ export const useListingZip = () => {
         fileLink.click()
       })
       setZipCompleted(true)
+      setSiteAlertMessage(t("users.exportSuccess"), "success")
     } catch (err) {
       setZipExportError(true)
     }

--- a/sites/partners/src/page_content/locale_overrides/general.json
+++ b/sites/partners/src/page_content/locale_overrides/general.json
@@ -323,6 +323,7 @@
   "t.endTime": "End Time",
   "t.enterAmount": "Enter amount",
   "t.export": "Export",
+  "t.exportSuccess": "The file has been exported",
   "t.exportToCSV": "Export to CSV",
   "t.fileName": "File Name",
   "t.filter": "Filter",
@@ -369,6 +370,5 @@
   "users.resendInvite": "Resend Invite",
   "users.totalUsers": "total users",
   "users.unconfirmed": "Unconfirmed",
-  "users.userDetails": "User Details",
-  "users.exportSuccess": "The File has been exported"
+  "users.userDetails": "User Details"
 }

--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -153,12 +153,7 @@ export default function ListingsList() {
       <PageHeader title={t("nav.listings")} className={"realtive md:pt-16"}>
         {zipCompleted && (
           <div className="flex absolute right-4 z-50 flex-col items-center">
-            <SiteAlert
-              dismissable
-              timeout={5000}
-              sticky={true}
-              alertMessage={{ message: t("listings.exportSuccess"), type: "success" }}
-            />
+            <SiteAlert dismissable timeout={5000} sticky={true} type="success" />
           </div>
         )}
       </PageHeader>

--- a/sites/partners/src/pages/users/index.tsx
+++ b/sites/partners/src/pages/users/index.tsx
@@ -153,15 +153,9 @@ const Users = () => {
       </Head>
       <PageHeader className={"relative md:pt-16"} title={t("nav.users")}>
         <div className="flex top-4 right-4 absolute z-50 flex-col items-center">
-          <SiteAlert type="success" timeout={5000} dismissable />
           {csvExportSuccess && (
-            <SiteAlert
-              timeout={5000}
-              dismissable
-              sticky={true}
-              alertMessage={{ message: t("users.exportSuccess"), type: "success" }}
-            />
-          )}{" "}
+            <SiteAlert type="success" timeout={5000} dismissable sticky={true} />
+          )}
         </div>
       </PageHeader>
       <section>
@@ -208,7 +202,7 @@ const Users = () => {
                 {profile?.roles?.isAdmin && (
                   <Button
                     className="mx-1"
-                    icon={faFileExport}
+                    icon={!csvExportLoading ? faFileExport : null}
                     iconSize="medium"
                     onClick={() => onExport()}
                     loading={csvExportLoading}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1594 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This addresses the three issues related to user export found in the bug bash yesterday
1. Spinner doesn't appear when you click the "Export to CSV" button
2. Only 10 users were getting returned
3. Success toaster kept reappearing, especially if you click "Users" navigation link after the toaster had been dismissed

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

In dev the first two are fairly hard to test since the export is fast enough that the spinner doesn't really appear and there are 10 or less users in the dev environment. You can add more users to get above the 10 threshold.

Steps to test # 3
- Go to users page and click on "export to CSV"
- wait for the success message to appear and disappear
- Click on the "USERS" navigation tab. 
- The toaster should not reappear

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
