### PR TITLE
1602/export memory improvements

### DIFF
--- a/backend/core/src/listings/listings-csv-exporter.service.ts
+++ b/backend/core/src/listings/listings-csv-exporter.service.ts
@@ -13,7 +13,6 @@ import {
   formatBedroom,
   getPaperAppUrls,
 } from "./helpers"
-import { summarizeUnits } from "../../src/shared/units-transformations"
 @Injectable({ scope: Scope.REQUEST })
 export class ListingsCsvExporterService {
   constructor(private readonly csvBuilder: CsvBuilder) {}
@@ -135,57 +134,53 @@ export class ListingsCsvExporterService {
   }
 
   exportUnitsFromObject(listings: any[]): string {
-    const unitGroupsFinal = []
+    const reformattedListings = []
     listings.forEach((listing) => {
-      const unitGroupRaw = []
-      listing.unitSummaries = summarizeUnits(listing.unitGroups, [])
       listing.unitGroups.forEach((unitGroup, idx) => {
-        unitGroupRaw.push({
+        reformattedListings.push({
           id: listing.id,
           name: listing.name,
           unitGroup,
           unitGroupSummary: listing.unitSummaries.unitGroupSummary[idx],
         })
       })
-      const unitGroupsFormatted = unitGroupRaw.map((formattedUnitGroup) => {
-        return {
-          "Listing ID": formattedUnitGroup.id,
-          "Listing Name": formattedUnitGroup.name,
-          "Unit Group ID": formattedUnitGroup.unitGroup.id,
-          "Unit Types": formattedUnitGroup.unitGroupSummary?.unitTypes
-            .map((unitType) => formatBedroom[unitType])
-            .join(", "),
-          "AMI Chart": [
-            ...new Set(
-              formattedUnitGroup.unitGroup?.amiLevels.map((level) => level.amiChart?.name)
-            ),
-          ].join(", "),
-          "AMI Level": formatRange(
-            formattedUnitGroup.unitGroupSummary?.amiPercentageRange?.min,
-            formattedUnitGroup.unitGroupSummary?.amiPercentageRange?.max,
-            "",
-            "%"
-          ),
-          "Rent Type": getRentTypes(formattedUnitGroup.unitGroup?.amiLevels),
-          "Monthly Rent": formatRentRange(
-            formattedUnitGroup.unitGroupSummary.rentRange,
-            formattedUnitGroup.unitGroupSummary.rentAsPercentIncomeRange
-          ),
-          "Affordable Unit Group Quantity": formattedUnitGroup.unitGroup?.totalCount,
-          "Unit Group Vacancies": formattedUnitGroup.unitGroup?.totalAvailable,
-          "Waitlist Status": formatYesNo(formattedUnitGroup.unitGroup?.openWaitlist),
-          "Minimum Occupancy": formattedUnitGroup.unitGroup?.minOccupancy,
-          "Maximum Occupancy": formattedUnitGroup.unitGroup?.maxOccupancy,
-          "Minimum Sq ft": formattedUnitGroup.unitGroup?.sqFeetMin,
-          "Maximum Sq ft": formattedUnitGroup.unitGroup?.sqFeetMax,
-          "Minimum Floor": formattedUnitGroup.unitGroup?.floorMin,
-          "Maximum Floor": formattedUnitGroup.unitGroup?.floorMax,
-          "Minimum Bathrooms": formattedUnitGroup.unitGroup?.bathroomMin,
-          "Maximum Bathrooms": formattedUnitGroup.unitGroup?.bathroomMax,
-        }
-      })
-      unitGroupsFinal.push(...unitGroupsFormatted)
     })
-    return this.csvBuilder.buildFromIdIndex(unitGroupsFinal)
+
+    const unitsFormatted = reformattedListings.map((listing) => {
+      return {
+        "Listing ID": listing.id,
+        "Listing Name": listing.name,
+        "Unit Group ID": listing.unitGroup.id,
+        "Unit Types": listing.unitGroupSummary?.unitTypes
+          .map((unitType) => formatBedroom[unitType])
+          .join(", "),
+        "AMI Chart": [
+          ...new Set(listing.unitGroup?.amiLevels.map((level) => level.amiChart?.name)),
+        ].join(", "),
+        "AMI Level": formatRange(
+          listing.unitGroupSummary?.amiPercentageRange?.min,
+          listing.unitGroupSummary?.amiPercentageRange?.max,
+          "",
+          "%"
+        ),
+        "Rent Type": getRentTypes(listing.unitGroup?.amiLevels),
+        "Monthly Rent": formatRentRange(
+          listing.unitGroupSummary.rentRange,
+          listing.unitGroupSummary.rentAsPercentIncomeRange
+        ),
+        "Affordable Unit Group Quantity": listing.unitGroup?.totalCount,
+        "Unit Group Vacancies": listing.unitGroup?.totalAvailable,
+        "Waitlist Status": formatYesNo(listing.unitGroup?.openWaitlist),
+        "Minimum Occupancy": listing.unitGroup?.minOccupancy,
+        "Maximum Occupancy": listing.unitGroup?.maxOccupancy,
+        "Minimum Sq ft": listing.unitGroup?.sqFeetMin,
+        "Maximum Sq ft": listing.unitGroup?.sqFeetMax,
+        "Minimum Floor": listing.unitGroup?.floorMin,
+        "Maximum Floor": listing.unitGroup?.floorMax,
+        "Minimum Bathrooms": listing.unitGroup?.bathroomMin,
+        "Maximum Bathrooms": listing.unitGroup?.bathroomMax,
+      }
+    })
+    return this.csvBuilder.buildFromIdIndex(unitsFormatted)
   }
 }

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -316,7 +316,12 @@ export class ListingsService {
       this.listingRepository.createQueryBuilder("listing"),
       "unitsExport"
     ).getViewQb()
+
     const unitData = await unitsQb.where("listing.id IN (:...listingIds)", { listingIds }).getMany()
+
+    unitData.forEach((listing) => {
+      listing.unitSummaries = summarizeUnits(listing.unitGroups, [])
+    })
 
     return {
       unitData,

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -316,10 +316,11 @@ export class ListingsService {
       this.listingRepository.createQueryBuilder("listing"),
       "unitsExport"
     ).getViewQb()
-    const unitDataRaw = await unitsQb
-      .where("listing.id IN (:...listingIds)", { listingIds })
-      .getMany()
-    const unitData = await this.addUnitSummariesToListings(unitDataRaw)
+    const unitData = await unitsQb.where("listing.id IN (:...listingIds)", { listingIds }).getMany()
+
+    unitData.forEach((listing) => {
+      listing.unitSummaries = summarizeUnits(listing.unitGroups, [])
+    })
 
     return {
       unitData,

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -318,10 +318,6 @@ export class ListingsService {
     ).getViewQb()
     const unitData = await unitsQb.where("listing.id IN (:...listingIds)", { listingIds }).getMany()
 
-    unitData.forEach((listing) => {
-      listing.unitSummaries = summarizeUnits(listing.unitGroups, [])
-    })
-
     return {
       unitData,
       listingData,


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1602 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

After recent conversations with Yazeed, I've realized that this ticket was presented as much broader than the reality of the work. I had initially understood the memory concerns to be sweeping and was looking for the most marginal improvements (ie. opting for in-place changes), however, the concerns were really surrounding the typeorm-related pieces. As a result, the only impactful change to be made is the shift away from the addUnitSummariesToListings function which unnecessarily queried the database to retrieve data that had already been queried for. I was able to bypass by using the formatting function used within the addUnitSummariesToListings on the unit data that had already been retrieved. This is a strict improvement to memory usage given there is one less database query involved in the CSV export.

Beyond this, the remaining use of Typeorm is based on custom queries that are required for fill the export and cannot be further optimized. 

## How Can This Be Tested/Reviewed?

This can be tested by ensuring that the Listings Export, particularly the unit pieces are functional.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
