### PR TITLE
fix: cant see buttons in drawer footer

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -162,7 +162,7 @@
 
     @supports not (height: 100dvh) {
       .drawer__body {
-        padding-bottom: var(--bloom-s16);
+        padding-bottom: var(--bloom-s24);
         @screen md {
           padding-bottom: 0;
         }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -154,10 +154,9 @@
     }
   }
 
-  // .drawer {
-  //   --content-padding: 0;
-  //   --content-height: 100%;
-  // }
+  .drawer {
+    --content-padding: 0;
+  }
 
   .page-header {
     --inverse-background-color: var(--bloom-color-primary-darker);

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -154,10 +154,10 @@
     }
   }
 
-  .drawer {
-    --content-padding: 0;
-    --content-height: 100%;
-  }
+  // .drawer {
+  //   --content-padding: 0;
+  //   --content-height: 100%;
+  // }
 
   .page-header {
     --inverse-background-color: var(--bloom-color-primary-darker);

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -162,9 +162,8 @@
 
     @supports not (height: 100dvh) {
       .drawer__body {
-        padding-bottom: var(--bloom-s24);
-        @screen md {
-          padding-bottom: 0;
+        @media (max-width: $screen-sm) {
+          padding-bottom: var(--bloom-s32);
         }
       }
     }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -156,13 +156,17 @@
 
   .drawer {
     --content-padding: 0;
-
     @supports (height: 100dvh) {
       height: 100dvh;
     }
 
     @supports not (height: 100dvh) {
-      padding-bottom: var(--bloom-s8);
+      .drawer__body {
+        padding-bottom: var(--bloom-s16);
+        @screen md {
+          padding-bottom: 0;
+        }
+      }
     }
   }
 

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -156,6 +156,7 @@
 
   .drawer {
     --content-padding: 0;
+    height: 100svh;
   }
 
   .page-header {

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -156,7 +156,14 @@
 
   .drawer {
     --content-padding: 0;
-    height: 100svh;
+
+    @supports (height: 100dvh) {
+      height: 100dvh;
+    }
+
+    @supports not (height: 100dvh) {
+      padding-bottom: var(--bloom-s8);
+    }
   }
 
   .page-header {


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #1641

- [x] This change addresses the issue in full

## Description

Allows users to see the buttons in the footer of the filter modal on the public site.

## How Can This Be Tested/Reviewed?

You have to test on a mobile device - the issue doesn't appear in the mobile emulator. You can visit the [deploy preview link](https://deploy-preview-1642--detroit-public-staging.netlify.app/).

This issue in part stems from the fact that the URL across different mobile browsers is in a different place and is a different height, so `100vh` is treated differently. The URL box in latest Safari is on the bottom vs in Chrome it's on the top. 

There are new dynamic viewport values that take this difference into account on mobile (documentation [here](https://web.dev/articles/viewport-units)). This looks to work great on recent browsers, but because it's new it's not supported across all versions. When the new value is not supported, I'm just manually adding bottom padding below the footer so that the buttons sit above the mobile browser footer. It's not perfect and there's extra space, but the buttons are accessible as a short term fix. You can test this unsupported version in BrowserStack on the iPhone 12 emulator using the deploy preview to see the other styles take effect (also below).

![Screenshot 2023-10-16 at 11 59 12 AM](https://github.com/CityOfDetroit/bloom/assets/65367387/604b9402-6731-49b3-a779-0aa942c0af2d)

The seeds Dialog and Drawer are close to being merged, and with the uptake of that and the fact that the footer behavior is different in the new one where the footer is sticky, hopefully that will resolve this issue in the long term. We're also chatting next week about what our support is across devices and browsers.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
